### PR TITLE
Feat: OI-131 definizione rotta authorize in OIDC controller

### DIFF
--- a/src/oneid/oneid-common/model/pom.xml
+++ b/src/oneid/oneid-common/model/pom.xml
@@ -24,5 +24,13 @@
             <groupId>org.opensaml</groupId>
             <artifactId>opensaml-saml-impl</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.amazonservices</groupId>
+            <artifactId>quarkus-amazon-dynamodb-enhanced</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/src/oneid/oneid-common/model/src/main/java/it/pagopa/oneid/common/Client.java
+++ b/src/oneid/oneid-common/model/src/main/java/it/pagopa/oneid/common/Client.java
@@ -1,24 +1,41 @@
 package it.pagopa.oneid.common;
 
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Data;
-import org.opensaml.saml.saml2.metadata.RequestedAttribute;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 
-import java.util.ArrayList;
+import java.util.List;
 
+@DynamoDbBean
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
+
 public class Client {
 
+    @Getter(onMethod_ = @DynamoDbPartitionKey)
+    @NotNull
     private String clientId;
 
+    @NotNull
     private String friendlyName;
 
-    private ArrayList<String> callbackURI;
+    @NotNull
+    private List<String> callbackURI;// TODO it should be String array
 
-    private ArrayList<RequestedAttribute> requestedParameters;
+    @NotNull
+    private List<String> requestedParameters; // TODO it should be String array
 
+    @NotNull
     private int acsIndex;
 
+    @NotNull
     private int attributeIndex;
 
+    @NotNull
     private boolean isActive;
 }

--- a/src/oneid/oneid-common/model/src/main/java/it/pagopa/oneid/common/Client.java
+++ b/src/oneid/oneid-common/model/src/main/java/it/pagopa/oneid/common/Client.java
@@ -1,9 +1,11 @@
 package it.pagopa.oneid.common;
 
+import lombok.Data;
 import org.opensaml.saml.saml2.metadata.RequestedAttribute;
 
 import java.util.ArrayList;
 
+@Data
 public class Client {
 
     private String clientId;

--- a/src/oneid/oneid-ecs-core/Dockerfile
+++ b/src/oneid/oneid-ecs-core/Dockerfile
@@ -14,21 +14,21 @@ USER quarkus
 
 WORKDIR /code
 
-# Build oneid-ecs-core using oneid-ecs-core-aggregate and native profile
-RUN ./mvnw -f pom.xml -B package -P oneid-ecs-core-aggregate,native
+# Build oneid-ecs-core using oneid-ecs-core-aggregate
+RUN ./mvnw -f pom.xml -B package -P oneid-ecs-core-aggregate
 
 ## Stage 2 : create the docker final image
-FROM quay.io/quarkus/quarkus-micro-image:2.0
+FROM registry.access.redhat.com/ubi8/openjdk-21-runtime:1.20-2
 WORKDIR /work/
-COPY --from=build /code/oneid-ecs-core/target/*-runner /work/application
 
-# set up permissions for user `1001`
-RUN chmod 775 /work /work/application \
-  && chown -R 1001 /work \
-  && chmod -R "g+rwX" /work \
-  && chown -R 1001:root /work
+COPY --from=build /code/oneid-ecs-core/target/quarkus-app/lib/ /deployments/lib/
+COPY --from=build /code/oneid-ecs-core/target/quarkus-app/*.jar /deployments/
+COPY --from=build /code/oneid-ecs-core/target/quarkus-app/app/ /deployments/app/
+COPY --from=build /code/oneid-ecs-core/target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8080
-USER 1001
+USER 185
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
 
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
+ENTRYPOINT [ "/opt/jboss/container/java/run/run-java.sh" ]

--- a/src/oneid/oneid-ecs-core/Dockerfile.native
+++ b/src/oneid/oneid-ecs-core/Dockerfile.native
@@ -1,0 +1,34 @@
+## Stage 1 : build with maven builder image with native capabilities
+FROM quay.io/quarkus/ubi-quarkus-graalvmce-builder-image:jdk-21 AS build
+# Copy all needed files and directories
+# Parent pom
+COPY  --chown=quarkus:quarkus ../pom.xml /code/
+# Maven wrapper files
+COPY  --chown=quarkus:quarkus ../mvnw /code/mvnw
+COPY  --chown=quarkus:quarkus ../.mvn /code/.mvn
+# oneid-common, oneid-ecs-core
+COPY --chown=quarkus:quarkus ../oneid-common /code/oneid-common
+COPY --chown=quarkus:quarkus ../oneid-ecs-core /code/oneid-ecs-core
+
+USER quarkus
+
+WORKDIR /code
+
+# Build oneid-ecs-core using oneid-ecs-core-aggregate and native profile
+RUN ./mvnw -f pom.xml -B package -P oneid-ecs-core-aggregate,native
+
+## Stage 2 : create the docker final image
+FROM quay.io/quarkus/quarkus-micro-image:2.0
+WORKDIR /work/
+COPY --from=build /code/oneid-ecs-core/target/*-runner /work/application
+
+# set up permissions for user `1001`
+RUN chmod 775 /work /work/application \
+  && chown -R 1001 /work \
+  && chmod -R "g+rwX" /work \
+  && chown -R 1001:root /work
+
+EXPOSE 8080
+USER 1001
+
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]

--- a/src/oneid/oneid-ecs-core/pom.xml
+++ b/src/oneid/oneid-ecs-core/pom.xml
@@ -113,11 +113,6 @@
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
 
     </dependencies>
 

--- a/src/oneid/oneid-ecs-core/pom.xml
+++ b/src/oneid/oneid-ecs-core/pom.xml
@@ -117,7 +117,6 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.16.1</version>
         </dependency>
 
     </dependencies>

--- a/src/oneid/oneid-ecs-core/pom.xml
+++ b/src/oneid/oneid-ecs-core/pom.xml
@@ -62,6 +62,22 @@
             <artifactId>opensaml-saml-impl</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.opensaml</groupId>
+            <artifactId>opensaml-xmlsec-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opensaml</groupId>
+            <artifactId>opensaml-security-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opensaml</groupId>
+            <artifactId>opensaml-security-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opensaml</groupId>
+            <artifactId>opensaml-profile-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>oauth2-oidc-sdk</artifactId>
         </dependency>
@@ -93,6 +109,17 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>url-connection-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.16.1</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/ClientConnector.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/ClientConnector.java
@@ -1,0 +1,10 @@
+package it.pagopa.oneid.connector;
+
+import it.pagopa.oneid.common.Client;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+public interface ClientConnector {
+    Optional<ArrayList<Client>> findAll();
+}

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/ClientConnectorImpl.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/ClientConnectorImpl.java
@@ -1,0 +1,45 @@
+package it.pagopa.oneid.connector;
+
+import it.pagopa.oneid.common.Client;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
+import software.amazon.awssdk.enhanced.dynamodb.model.ScanEnhancedRequest;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+@ApplicationScoped
+public class ClientConnectorImpl implements ClientConnector {
+    // TODO how to obtain TABLE_NAME
+    private static final String TABLE_NAME = "Client";
+
+    private final DynamoDbTable<Client> clientMapper;
+
+    @Inject
+    ClientConnectorImpl(DynamoDbEnhancedClient dynamoDbEnhancedClient) {
+        clientMapper = dynamoDbEnhancedClient.table(TABLE_NAME, TableSchema.fromBean(Client.class));
+    }
+
+    @Override
+    public Optional<ArrayList<Client>> findAll() {
+
+        ArrayList<Client> clients = new ArrayList<>();
+        ScanEnhancedRequest request = ScanEnhancedRequest.builder()
+                .build();
+
+        PageIterable<Client> pagedResults = clientMapper.scan(request);
+        pagedResults.items().stream()
+                .forEach(
+                        clients::add
+                );
+
+        if (!clients.isEmpty()) {
+            return Optional.of(clients);
+        }
+        return Optional.empty();
+    }
+}

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/CallbackURINotFoundException.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/CallbackURINotFoundException.java
@@ -1,4 +1,18 @@
 package it.pagopa.oneid.exception;
 
-public class CallbackURINotFoundException extends RuntimeException {
+import it.pagopa.oneid.exception.enums.ErrorCode;
+
+public class CallbackURINotFoundException extends OneIdentityException {
+
+    public CallbackURINotFoundException() {
+        super(ErrorCode.CALLBACK_URINOT_FOUND);
+    }
+
+    public CallbackURINotFoundException(String customErrorMessage) {
+        super(customErrorMessage);
+    }
+
+    public CallbackURINotFoundException(Throwable cause) {
+        super(cause);
+    }
 }

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/CallbackURINotFoundException.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/CallbackURINotFoundException.java
@@ -1,0 +1,4 @@
+package it.pagopa.oneid.exception;
+
+public class CallbackURINotFoundException extends RuntimeException {
+}

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/ClientNotFoundException.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/ClientNotFoundException.java
@@ -1,0 +1,4 @@
+package it.pagopa.oneid.exception;
+
+public class ClientNotFoundException extends RuntimeException {
+}

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/ClientNotFoundException.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/ClientNotFoundException.java
@@ -1,4 +1,17 @@
 package it.pagopa.oneid.exception;
 
-public class ClientNotFoundException extends RuntimeException {
+import it.pagopa.oneid.exception.enums.ErrorCode;
+
+public class ClientNotFoundException extends OneIdentityException {
+    public ClientNotFoundException() {
+        super(ErrorCode.CLIENT_NOT_FOUND);
+    }
+
+    public ClientNotFoundException(String customErrorMessage) {
+        super(customErrorMessage);
+    }
+
+    public ClientNotFoundException(Throwable cause) {
+        super(cause);
+    }
 }

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/GenericAuthnRequestCreationException.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/GenericAuthnRequestCreationException.java
@@ -5,7 +5,7 @@ import it.pagopa.oneid.exception.enums.ErrorCode;
 public class GenericAuthnRequestCreationException extends OneIdentityException {
 
     public GenericAuthnRequestCreationException() {
-        super(ErrorCode.GENERIC_AUTHN_REQUEST_CREATION_EXCEPTION);
+        super(ErrorCode.GENERIC_AUTHN_REQUEST_CREATION);
     }
 
     public GenericAuthnRequestCreationException(String message) {

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/IDPNotFoundException.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/IDPNotFoundException.java
@@ -1,4 +1,17 @@
 package it.pagopa.oneid.exception;
 
-public class IDPNotFoundException extends RuntimeException {
+import it.pagopa.oneid.exception.enums.ErrorCode;
+
+public class IDPNotFoundException extends OneIdentityException {
+    public IDPNotFoundException() {
+        super(ErrorCode.IDPNOT_FOUND);
+    }
+
+    public IDPNotFoundException(String customErrorMessage) {
+        super(customErrorMessage);
+    }
+
+    public IDPNotFoundException(Throwable cause) {
+        super(cause);
+    }
 }

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/IDPNotFoundException.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/IDPNotFoundException.java
@@ -1,0 +1,4 @@
+package it.pagopa.oneid.exception;
+
+public class IDPNotFoundException extends RuntimeException {
+}

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/SAMLUtilsException.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/SAMLUtilsException.java
@@ -6,7 +6,7 @@ import it.pagopa.oneid.exception.enums.ErrorCode;
 public class SAMLUtilsException extends OneIdentityException {
 
     public SAMLUtilsException() {
-        super(ErrorCode.SAMLUTILS_EXCEPTION);
+        super(ErrorCode.SAMLUTILS_ERROR);
     }
 
     public SAMLUtilsException(String customErrorMessage) {

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/enums/ErrorCode.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/enums/ErrorCode.java
@@ -7,8 +7,12 @@ public enum ErrorCode {
 
     MARSHALLER_ERROR("MARSHALLER_ERROR", "Empty marshaller"),
     IDPSSOENDPOINT_NOT_FOUND("IDPSSOENDPOINT_NOT_FOUND", "Unable to find the idp-sso endpoint"),
-    GENERIC_AUTHN_REQUEST_CREATION_EXCEPTION("GENERIC_AUTHN_REQUEST_CREATION_EXCEPTION", "Generic AuthnRequest Exception"),
-    SAMLUTILS_EXCEPTION("SAMLUTILS_EXCEPTION", "Generic exception inside SAMLUtils");
+    GENERIC_AUTHN_REQUEST_CREATION("GENERIC_AUTHN_REQUEST_CREATION", "Generic AuthnRequest Exception"),
+    SAMLUTILS_ERROR("SAMLUTILS_ERROR", "Generic exception inside SAMLUtils"),
+    CALLBACK_URINOT_FOUND("CALLBACK_URINOT_FOUND", ""),
+    CLIENT_NOT_FOUND("CLIENT_NOT_FOUND", ""),
+    IDPNOT_FOUND("IDPNOT_FOUND", ""),
+    ;
 
 
     private final String errorCode;

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/mapper/ExceptionMapper.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/mapper/ExceptionMapper.java
@@ -1,8 +1,7 @@
 package it.pagopa.oneid.exception.mapper;
 
 
-import it.pagopa.oneid.exception.GenericAuthnRequestCreationException;
-import it.pagopa.oneid.exception.IDPSSOEndpointNotFoundException;
+import it.pagopa.oneid.exception.*;
 import it.pagopa.oneid.model.ErrorResponse;
 import jakarta.ws.rs.core.Response;
 import org.jboss.resteasy.reactive.RestResponse;
@@ -14,6 +13,13 @@ import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 public class ExceptionMapper {
 
     @ServerExceptionMapper
+    public RestResponse<ErrorResponse> mapGenericException(Exception genericException) {
+        Response.Status status = INTERNAL_SERVER_ERROR;
+        String message = "Error during execution.";
+        return RestResponse.status(status, buildErrorResponse(status, message));
+    }
+
+    @ServerExceptionMapper
     public RestResponse<ErrorResponse> mapGenericAuthnRequestCreationException(GenericAuthnRequestCreationException genericAuthnRequestCreationException) {
         Response.Status status = INTERNAL_SERVER_ERROR;
         String message = "Error during generation of AuthnRequest.";
@@ -21,9 +27,37 @@ public class ExceptionMapper {
     }
 
     @ServerExceptionMapper
+    public RestResponse<ErrorResponse> mapSamlUtilsException(SAMLUtilsException samlUtilsException) {
+        Response.Status status = INTERNAL_SERVER_ERROR;
+        String message = "Error during SAMLUtils execution.";
+        return RestResponse.status(status, buildErrorResponse(status, message));
+    }
+
+    @ServerExceptionMapper
     public RestResponse<ErrorResponse> mapIDPSSOEndpointNotFoundException(IDPSSOEndpointNotFoundException idpssoEndpointNotFoundException) {
         Response.Status status = BAD_REQUEST;
         String message = "IDPSSO endpoint not found for selected idp.";
+        return RestResponse.status(status, buildErrorResponse(status, message));
+    }
+
+    @ServerExceptionMapper
+    public RestResponse<ErrorResponse> mapCallbackUriNotFoundException(CallbackURINotFoundException callbackURINotFoundException) {
+        Response.Status status = BAD_REQUEST;
+        String message = "Callback URI not found.";
+        return RestResponse.status(status, buildErrorResponse(status, message));
+    }
+
+    @ServerExceptionMapper
+    public RestResponse<ErrorResponse> mapClientNotFoundException(ClientNotFoundException clientNotFoundException) {
+        Response.Status status = BAD_REQUEST;
+        String message = "Client not found.";
+        return RestResponse.status(status, buildErrorResponse(status, message));
+    }
+
+    @ServerExceptionMapper
+    public RestResponse<ErrorResponse> mapIdpNotFoundException(IDPNotFoundException idpNotFoundException) {
+        Response.Status status = BAD_REQUEST;
+        String message = "IDP not found";
         return RestResponse.status(status, buildErrorResponse(status, message));
     }
 

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/session/SAMLSession.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/session/SAMLSession.java
@@ -1,15 +1,27 @@
 package it.pagopa.oneid.model.session;
 
+import it.pagopa.oneid.model.session.enums.RecordType;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 
 @EqualsAndHashCode(callSuper = true)
 @DynamoDbBean
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class SAMLSession extends Session {
 
-    private String SAMLRequest; //TODO change in ?
+    @NotNull
+    private String SAMLRequest;
 
-    private String SAMLResponse; //TODO change in ?
+    private String SAMLResponse;
+
+    public SAMLSession(@NotNull String SAMLRequestID, @NotNull RecordType recordType, @NotNull long creationTime, @NotNull long ttl, String SAMLRequest) {
+        super(SAMLRequestID, recordType, creationTime, ttl);
+        this.SAMLRequest = SAMLRequest;
+    }
 }

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/session/Session.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/session/Session.java
@@ -1,23 +1,32 @@
 package it.pagopa.oneid.model.session;
 
 import it.pagopa.oneid.model.session.enums.RecordType;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
 
 @DynamoDbBean
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public abstract class Session {
 
     @Getter(onMethod_ = @DynamoDbPartitionKey)
+    @NotNull
     private String SAMLRequestID;
 
     @Getter(onMethod_ = @DynamoDbSortKey)
+    @NotNull
     private RecordType recordType;
 
-    private Long creationTime;
+    @NotNull
+    private long creationTime;
 
-    private Long ttl;
+    @NotNull
+    private long ttl;
 }

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/producers/ClientProducer.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/producers/ClientProducer.java
@@ -1,0 +1,31 @@
+package it.pagopa.oneid.producers;
+
+import it.pagopa.oneid.common.Client;
+import it.pagopa.oneid.connector.ClientConnectorImpl;
+import it.pagopa.oneid.exception.ClientNotFoundException;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Produces;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+@ApplicationScoped
+public class ClientProducer {
+
+    @Inject
+    ClientConnectorImpl clientConnectorImpl;
+
+    @ApplicationScoped
+    @Produces
+    HashMap<String, Client> clientsMap() {
+        HashMap<String, Client> map = new HashMap<>();
+        ArrayList<Client> clients =
+                clientConnectorImpl.findAll()
+                        .orElseThrow(ClientNotFoundException::new); // TODO valutare se cambiare eccezione
+
+        clients.forEach(client -> map.put(client.getClientId(), client));
+
+        return map;
+    }
+}

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/producers/ClientProducer.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/producers/ClientProducer.java
@@ -19,7 +19,7 @@ public class ClientProducer {
 
     @ApplicationScoped
     @Produces
-    Map<String, Client> clientsMap() {
+    Map<String, Client> clientsMap() throws ClientNotFoundException {
         Map<String, Client> map = new HashMap<>();
         ArrayList<Client> clients =
                 clientConnectorImpl.findAll()

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/producers/ClientProducer.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/producers/ClientProducer.java
@@ -9,6 +9,7 @@ import jakarta.ws.rs.Produces;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 
 @ApplicationScoped
 public class ClientProducer {
@@ -18,8 +19,8 @@ public class ClientProducer {
 
     @ApplicationScoped
     @Produces
-    HashMap<String, Client> clientsMap() {
-        HashMap<String, Client> map = new HashMap<>();
+    Map<String, Client> clientsMap() {
+        Map<String, Client> map = new HashMap<>();
         ArrayList<Client> clients =
                 clientConnectorImpl.findAll()
                         .orElseThrow(ClientNotFoundException::new); // TODO valutare se cambiare eccezione

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SAMLService.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SAMLService.java
@@ -5,8 +5,10 @@ import it.pagopa.oneid.exception.IDPSSOEndpointNotFoundException;
 import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface SAMLService {
 
@@ -17,5 +19,7 @@ public interface SAMLService {
     boolean validateSAMLResponse(Response SAMLResponse, String idpID);
 
     List<Attribute> getAttributesFromSAMLResponse(Response SAMLResponse);
+
+    Optional<EntityDescriptor> getEntityDescriptorFromEntityID(String entityID);
 
 }

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SAMLServiceImpl.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SAMLServiceImpl.java
@@ -16,9 +16,11 @@ import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.xmlsec.signature.Signature;
 import org.opensaml.xmlsec.signature.support.SignatureException;
 import org.opensaml.xmlsec.signature.support.Signer;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 import static it.pagopa.oneid.service.utils.SAMLUtils.*;
 
@@ -87,4 +89,12 @@ public class SAMLServiceImpl implements SAMLService {
     public List<Attribute> getAttributesFromSAMLResponse(Response SAMLResponse) {
         return List.of();
     }
+
+    @Override
+    public Optional<EntityDescriptor> getEntityDescriptorFromEntityID(String entityID) {
+
+        return samlUtils.getEntityDescriptor(entityID);
+
+    }
 }
+

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SAMLServiceImpl.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SAMLServiceImpl.java
@@ -13,10 +13,10 @@ import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 import org.opensaml.xmlsec.signature.Signature;
 import org.opensaml.xmlsec.signature.support.SignatureException;
 import org.opensaml.xmlsec.signature.support.Signer;
-import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 
 import java.time.Instant;
 import java.util.List;
@@ -73,7 +73,6 @@ public class SAMLServiceImpl implements SAMLService {
 
         return authnRequest;
     }
-
 
     @Override
     public Response getSAMLResponseFromString(String SAMLResponse) {

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/OIDCController.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/OIDCController.java
@@ -21,7 +21,7 @@ import it.pagopa.oneid.service.SAMLServiceImpl;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.HashMap;
+import java.util.Map;
 
 @Path(("/oidc"))
 public class OIDCController {
@@ -34,7 +34,7 @@ public class OIDCController {
     SessionServiceImpl<SAMLSession> samlSessionService;*/
 
     @Inject
-    HashMap<String, Client> clientsMap;
+    Map<String, Client> clientsMap;
 
     @GET
     @Path("/.well-known/openid-configuration")

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/OIDCController.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/OIDCController.java
@@ -1,9 +1,7 @@
 package it.pagopa.oneid.web.controller;
 
 import it.pagopa.oneid.common.Client;
-import it.pagopa.oneid.exception.CallbackURINotFoundException;
-import it.pagopa.oneid.exception.ClientNotFoundException;
-import it.pagopa.oneid.exception.IDPNotFoundException;
+import it.pagopa.oneid.exception.*;
 import it.pagopa.oneid.service.SAMLServiceImpl;
 import it.pagopa.oneid.web.dto.AuthorizationRequestDTOExtended;
 import it.pagopa.oneid.web.dto.TokenRequestDTOExtended;
@@ -13,14 +11,12 @@ import jakarta.validation.Valid;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 import org.opensaml.saml.saml2.core.AuthnRequest;
-import it.pagopa.oneid.exception.GenericAuthnRequestCreationException;
-import it.pagopa.oneid.exception.IDPSSOEndpointNotFoundException;
-import it.pagopa.oneid.service.SAMLServiceImpl;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Base64;
 import java.util.Map;
 
 @Path(("/oidc"))
@@ -53,7 +49,8 @@ public class OIDCController {
     @POST
     @Path("/authorize")
     @Produces(MediaType.TEXT_HTML)
-    public Response authorize(@BeanParam @Valid AuthorizationRequestDTOExtended authorizationRequestDTOExtended) throws IDPSSOEndpointNotFoundException, GenericAuthnRequestCreationException {
+    public Response authorize(@BeanParam @Valid AuthorizationRequestDTOExtended authorizationRequestDTOExtended) throws IDPSSOEndpointNotFoundException, GenericAuthnRequestCreationException, IDPNotFoundException, ClientNotFoundException, CallbackURINotFoundException {
+
         // TODO setup logging utility
 
         // TODO setup ExceptionHandler
@@ -80,16 +77,12 @@ public class OIDCController {
         String idpSSOEndpoint = idp.getIDPSSODescriptor("urn:oasis:names:tc:SAML:2.0:protocol").getSingleSignOnServices().getFirst().getLocation();
 
         // 4. Create SAML Authn Request using SAMLServiceImpl
-        // TODO implement and replace when layer ready
 
-        String encodedAuthnRequest = "test";
-        String encodedRelayStateString = "test";
-
-        /*AuthnRequest authnRequest = samlServiceImpl.buildAuthnRequest(authorizationRequestDTOExtended.getIdp(), client.getAcsIndex(), client.getAttributeIndex());
+        // TODO who owns spid levl?
+        AuthnRequest authnRequest = samlServiceImpl.buildAuthnRequest(authorizationRequestDTOExtended.getIdp(), client.getAcsIndex(), client.getAttributeIndex(), "");
 
         String encodedAuthnRequest = Base64.getEncoder().encodeToString(WebUtils.getStringValue(WebUtils.getElementValueFromAuthnRequest(authnRequest)).getBytes());
         String encodedRelayStateString = Base64.getEncoder().encodeToString(WebUtils.getRelayState(authorizationRequestDTOExtended).getBytes());
-        */
 
         // TODO  implement when layer ready
 

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/OIDCController.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/OIDCController.java
@@ -1,22 +1,34 @@
 package it.pagopa.oneid.web.controller;
 
-import it.pagopa.oneid.common.DummyClient;
-import it.pagopa.oneid.exception.GenericAuthnRequestCreationException;
-import it.pagopa.oneid.exception.IDPSSOEndpointNotFoundException;
+import it.pagopa.oneid.common.Client;
+import it.pagopa.oneid.exception.*;
 import it.pagopa.oneid.model.dto.AuthorizationRequestDTO;
-import it.pagopa.oneid.service.SAMLServiceImpl;
+import it.pagopa.oneid.model.session.SAMLSession;
+import it.pagopa.oneid.model.session.enums.RecordType;
 import it.pagopa.oneid.web.dto.TokenRequestDTOExtended;
+import it.pagopa.oneid.web.utils.WebUtils;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.opensaml.saml.saml2.core.AuthnRequest;
+import it.pagopa.oneid.exception.GenericAuthnRequestCreationException;
+import it.pagopa.oneid.exception.IDPSSOEndpointNotFoundException;
+import it.pagopa.oneid.service.SAMLServiceImpl;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
 
 @Path(("/oidc"))
-public class OIDCController {
+public class OIDCController<T> {
+
     @Inject
-    private SAMLServiceImpl samlServiceImpl;
+    SAMLServiceImpl samlServiceImpl;
+
+    @Inject
+    SessionServiceImpl<T> sessionServiceImpl;
 
     @GET
     @Path("/.well-known/openid-configuration")
@@ -34,9 +46,64 @@ public class OIDCController {
 
     @POST
     @Path("/authorize")
+    @Produces(MediaType.TEXT_HTML)
     public Response authorize(@BeanParam @Valid AuthorizationRequestDTO authorizationRequestDTO) throws IDPSSOEndpointNotFoundException, GenericAuthnRequestCreationException {
-        AuthnRequest authnRequest = samlServiceImpl.buildAuthnRequest("https://id.eht.eu", 0, 0, "");
-        return Response.ok(DummyClient.CLIENT_NAME).build();
+        // TODO setup logging utility
+
+
+        // TODO these hashmaps must be initialized during startup
+        // HashMap<String, IDP> idpsMap = new HashMap<String, String>(); -> from file
+        // HashMap<String, Client> clientsHashMap = new HashMap<String, Client>(); -> from DynamoDB
+
+        // TODO may these controls be executed by other components?
+
+        // 1. Check if idp exists leveraging on runtime map (CIE/SPID) {key: idp, value: idp sso endpoint}
+        if (!idpsMap.containsKey(authorizationRequestDTOExtended.getIdp())) {
+            throw new IDPNotFoundException();
+        }
+
+        // 2. Check if clientId exists leverage on runtime map {key: clientid, value: ClientRegistration}
+        if (!clientsHashMap.containsKey(authorizationRequestDTOExtended.getClientId())) {
+            throw new ClientNotFoundException();
+        }
+
+        // 3. Check if callbackUri exists among clientId parameters
+        if (!clientsHashMap.get(authorizationRequestDTOExtended.getClientId()).getCallbackURI().contains(authorizationRequestDTOExtended.getRedirectUri())) {
+            throw new CallbackURINotFoundException();
+        }
+
+        Client client = clientsHashMap.get(authorizationRequestDTOExtended.getClientId());
+        String idpSSOEndpoint = idpsMap.get(authorizationRequestDTOExtended.getIdp()).getSSOEndpoint();
+
+        // 4. Create SAML Authn Request using SAMLServiceImpl
+        AuthnRequest authnRequest = samlServiceImpl.buildAuthnRequest(authorizationRequestDTOExtended.getIdp(), client.getAcsIndex(), client.getAttributeIndex());
+
+        String encodedAuthnRequest = Base64.getEncoder().encodeToString(WebUtils.getStringValue(WebUtils.getElementValueFromAuthnRequest(authnRequest)).getBytes());
+        String encodedRelayStateString = Base64.getEncoder().encodeToString(WebUtils.getRelayState(authorizationRequestDTOExtended).getBytes());
+
+        // 5. Persist SAMLSession
+
+        // Get the current time in epoch second format
+        long creationTime = Instant.now().getEpochSecond();
+
+        // Calculate the expiration time (2 days from now) in epoch second format
+        long ttl = Instant.now().plus(2, ChronoUnit.DAYS).getEpochSecond();
+
+        SAMLSession samlSession = new SAMLSession(authnRequest.getID(), RecordType.SAML, creationTime, ttl, encodedAuthnRequest);
+        sessionServiceImpl.saveSession(samlSession);
+
+        String redirectAutoSubmitPOSTForm = "<form method='post' action=" + idpSSOEndpoint
+                + " id='SAMLRequestForm'>" +
+                "<input type='hidden' name='SAMLRequest' value=" + encodedAuthnRequest + " />" +
+                "<input type='hidden' name='RelayState' value=" + encodedRelayStateString + " />" +
+                "<input id='SAMLSubmitButton' type='submit' value='Submit' />" +
+                "</form>" +
+                "<script>document.getElementById('SAMLSubmitButton').style.visibility='hidden'; " +
+                "document.getElementById('SAMLRequestForm').submit();</script>";
+
+        return Response
+                .ok(redirectAutoSubmitPOSTForm)
+                .build();
     }
 
     @POST

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/OneIDController.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/OneIDController.java
@@ -1,6 +1,6 @@
 package it.pagopa.oneid.web.controller;
 
-import it.pagopa.oneid.web.dto.AuthorizationRequestDTOExtended;
+import it.pagopa.oneid.model.dto.AuthorizationRequestDTO;
 import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -22,7 +22,7 @@ public class OneIDController {
     @GET
     @Path("/login")
     @Produces(MediaType.TEXT_HTML)
-    public Response login(@BeanParam AuthorizationRequestDTOExtended authorizationRequestDTOExtended) {
+    public Response login(@BeanParam AuthorizationRequestDTO authorizationRequestDTO) {
         // TODO remove this Mock and set @Valid
         String localIDP = "https://localhost:8443/samlsso";
         String localDemoIDP = "https://localhost:8443/demo/samlsso";

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/dto/AuthorizationRequestDTOExtended.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/dto/AuthorizationRequestDTOExtended.java
@@ -3,8 +3,10 @@ package it.pagopa.oneid.web.dto;
 import it.pagopa.oneid.model.dto.AuthorizationRequestDTO;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.jboss.resteasy.reactive.RestQuery;
 
+@EqualsAndHashCode(callSuper = true)
 @Data
 public class AuthorizationRequestDTOExtended extends AuthorizationRequestDTO {
     @RestQuery

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/dto/TokenRequestDTOExtended.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/dto/TokenRequestDTOExtended.java
@@ -3,7 +3,9 @@ package it.pagopa.oneid.web.dto;
 import it.pagopa.oneid.model.dto.TokenRequestDTO;
 import jakarta.ws.rs.HeaderParam;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode(callSuper = true)
 @Data
 public class TokenRequestDTOExtended extends TokenRequestDTO {
 

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/utils/WebUtils.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/utils/WebUtils.java
@@ -1,0 +1,60 @@
+package it.pagopa.oneid.web.utils;
+
+import it.pagopa.oneid.model.dto.AuthorizationRequestDTO;
+import net.minidev.json.JSONObject;
+import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
+import org.opensaml.core.xml.io.Marshaller;
+import org.opensaml.core.xml.io.MarshallingException;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.w3c.dom.Element;
+
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.StringWriter;
+
+public class WebUtils {
+
+
+    public static String getStringValue(Element element) {
+        StreamResult result = new StreamResult(new StringWriter());
+        try {
+            TransformerFactory
+                    .newInstance()
+                    .newTransformer()
+                    .transform(new DOMSource(element), result);
+        } catch (TransformerException e) {
+            throw new RuntimeException(e);
+        }
+        return result.getWriter().toString();
+    }
+
+    public static Element getElementValueFromAuthnRequest(AuthnRequest authnRequest) {
+        Marshaller out = XMLObjectProviderRegistrySupport.getMarshallerFactory().getMarshaller(authnRequest);
+
+        Element plaintextElement = null;
+        try {
+            plaintextElement = out.marshall(authnRequest);
+        } catch (MarshallingException e) {
+            throw new RuntimeException(e);
+        }
+
+        return plaintextElement;
+    }
+
+    public static String getRelayState(AuthorizationRequestDTO authorizationRequestDTO) {
+        JSONObject relayState = new JSONObject();
+
+        relayState.put("response_type", authorizationRequestDTO.getResponseType());
+        relayState.put("scope", authorizationRequestDTO.getScope());
+        relayState.put("client_id", authorizationRequestDTO.getClientId());
+        relayState.put("state", authorizationRequestDTO.getState());
+        relayState.put("nonce", authorizationRequestDTO.getNonce());
+        relayState.put("callback_uri", authorizationRequestDTO.getRedirectUri());
+
+        return relayState.toJSONString();
+    }
+
+
+}

--- a/src/oneid/pom.xml
+++ b/src/oneid/pom.xml
@@ -133,6 +133,11 @@
                 <artifactId>nimbus-jose-jwt</artifactId>
                 <version>9.39.3</version>
             </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.16.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <profiles>

--- a/src/oneid/pom.xml
+++ b/src/oneid/pom.xml
@@ -60,6 +60,32 @@
                 <scope>compile</scope>
             </dependency>
             <dependency>
+                <groupId>org.opensaml</groupId>
+                <artifactId>opensaml-soap-api</artifactId>
+                <version>${opensaml.version}</version>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.opensaml</groupId>
+                <artifactId>opensaml-xmlsec-api</artifactId>
+                <version>${opensaml.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.opensaml</groupId>
+                <artifactId>opensaml-security-api</artifactId>
+                <version>${opensaml.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.opensaml</groupId>
+                <artifactId>opensaml-security-impl</artifactId>
+                <version>${opensaml.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.opensaml</groupId>
+                <artifactId>opensaml-profile-api</artifactId>
+                <version>${opensaml.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>${quarkus.platform.group-id}</groupId>
                 <artifactId>${quarkus.platform.artifact-id}</artifactId>
                 <version>${quarkus.platform.version}</version>

--- a/src/oneid/pom.xml
+++ b/src/oneid/pom.xml
@@ -133,11 +133,6 @@
                 <artifactId>nimbus-jose-jwt</artifactId>
                 <version>9.39.3</version>
             </dependency>
-            <dependency>
-                <groupId>commons-io</groupId>
-                <artifactId>commons-io</artifactId>
-                <version>2.16.1</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
     <profiles>


### PR DESCRIPTION
This PR adds:
- Dockerfile for JVM mode
- `ClientProducer` bean to load Client information at application startup (clientId, callback_uri, acs_index ecc..)
- Custom exception classes for `oidc/authorize` route

[JIRA TICKET](https://pagopa.atlassian.net/browse/OI-131)