### PR TITLE
Feat: Add implementations for SessionConnector methods needed for SamlSession

### DIFF
--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/SessionConnector.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/SessionConnector.java
@@ -19,7 +19,7 @@ public interface SessionConnector<T extends Session> {
   Optional<T> findSession(String identifier, RecordType recordType) throws SessionException;
 
 
-  void updateSAMLSession(String samlRequestID, String SAMLResponse);
+  void updateSAMLSession(String samlRequestID, String SAMLResponse) throws SessionException;
 
 
 }

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/SessionConnector.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/SessionConnector.java
@@ -2,6 +2,7 @@ package it.pagopa.oneid.connector;
 
 import it.pagopa.oneid.exception.SessionException;
 import it.pagopa.oneid.model.session.Session;
+import it.pagopa.oneid.model.session.enums.RecordType;
 import java.util.Optional;
 
 public interface SessionConnector<T extends Session> {
@@ -15,7 +16,7 @@ public interface SessionConnector<T extends Session> {
   //   SAMLRequestID for SAMLSession;
   //  authorizationCode for OIDCSession;
   //  accessToken for AccessTokenSession;
-  Optional<T> findSession(String identifier);
+  Optional<T> findSession(String identifier, RecordType recordType) throws SessionException;
 
 
   void updateSAMLSession(String samlRequestID, String SAMLResponse);

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/SessionConnectorImpl.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/SessionConnectorImpl.java
@@ -38,10 +38,7 @@ public class SessionConnectorImpl<T extends Session> implements SessionConnector
   public void saveSession(T session) throws SessionException {
     switch (session) {
       case SAMLSession samlSession -> samlSessionMapper.putItem(samlSession);
-      case OIDCSession oidcSession -> {
-        //TODO implement
-        break;
-      }
+      case OIDCSession oidcSession -> oidcSessionMapper.putItem(oidcSession);
       case AccessTokenSession accessTokenSession -> {
         //TODO implement
         break;

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/SessionConnectorImpl.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/SessionConnectorImpl.java
@@ -1,5 +1,6 @@
 package it.pagopa.oneid.connector;
 
+import io.quarkus.logging.Log;
 import it.pagopa.oneid.exception.SessionException;
 import it.pagopa.oneid.model.session.AccessTokenSession;
 import it.pagopa.oneid.model.session.OIDCSession;
@@ -7,10 +8,15 @@ import it.pagopa.oneid.model.session.SAMLSession;
 import it.pagopa.oneid.model.session.Session;
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Expression;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest;
 
 @Dependent
 public class SessionConnectorImpl<T extends Session> implements SessionConnector<T> {
@@ -20,9 +26,9 @@ public class SessionConnectorImpl<T extends Session> implements SessionConnector
   private static final String GSI_IDX_NAME = "gsi_code_idx";
 
 
+  private final DynamoDbTable<SAMLSession> samlSessionMapper;
   private final DynamoDbTable<OIDCSession> oidcSessionMapper;
   private final DynamoDbTable<AccessTokenSession> accessTokenSessionMapper;
-  private final DynamoDbTable<SAMLSession> samlSessionMapper;
 
   @Inject
   SessionConnectorImpl(DynamoDbEnhancedClient dynamoDbEnhancedClient) {
@@ -36,9 +42,45 @@ public class SessionConnectorImpl<T extends Session> implements SessionConnector
 
   @Override
   public void saveSession(T session) throws SessionException {
+    Log.debug("[SessionConnectorImpl.saveSession] start");
+    // TODO: find a better way to avoid duplication
     switch (session) {
-      case SAMLSession samlSession -> samlSessionMapper.putItem(samlSession);
-      case OIDCSession oidcSession -> oidcSessionMapper.putItem(oidcSession);
+      case SAMLSession samlSession -> {
+        try {
+          samlSessionMapper.putItem(
+              PutItemEnhancedRequest.builder(SAMLSession.class)
+                  .item(samlSession)
+                  .conditionExpression(
+                      Expression.builder().expression(
+                              "attribute_not_exists(SAMLRequestID)")
+                          .build())
+                  .build());
+        } catch (ConditionalCheckFailedException e) {
+          Log.debug(
+              "[SessionConnectorImpl.saveSession] a record with the same SAMLRequestID already exists");
+          throw new SessionException("Existing SAMLSession for the specified SAMLRequestID");
+        }
+        Log.debug("[SessionConnectorImpl.saveSession] successfully saved SamlSession");
+      }
+
+      case OIDCSession oidcSession -> {
+        try {
+          oidcSessionMapper.putItem(
+              PutItemEnhancedRequest.builder(OIDCSession.class)
+                  .item(oidcSession)
+                  .conditionExpression(
+                      Expression.builder().expression(
+                              "attribute_not_exists(SAMLRequestID)")
+                          .build())
+                  .build());
+
+        } catch (ConditionalCheckFailedException e) {
+          Log.debug(
+              "[SessionConnectorImpl.saveSession] a record with the same SAMLRequestID already exists");
+          throw new SessionException("Existing OIDCSession for the specified SAMLRequestID");
+        }
+        Log.debug("[SessionConnectorImpl.saveSession] successfully saved OIDCSession");
+      }
       case AccessTokenSession accessTokenSession -> {
         //TODO implement
         break;

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/utils/ConnectorConstants.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/utils/ConnectorConstants.java
@@ -1,0 +1,8 @@
+package it.pagopa.oneid.connector.utils;
+
+public abstract class ConnectorConstants {
+
+  public static int VALID_TIME_SAML = 15;
+  public static int VALID_TIME_OIDC = 1;
+  public static int VALID_TIME_ACCESS_TOKEN = 15;
+}

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/session/SAMLSession.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/session/SAMLSession.java
@@ -18,6 +18,8 @@ public class SAMLSession extends Session {
   @NotNull
   private String SAMLRequest;
 
+  // TODO: evaluate if this is better than throwing an exception on update
+  // @Getter(onMethod_ = @DynamoDbUpdateBehavior(UpdateBehavior.WRITE_IF_NOT_EXISTS))
   private String SAMLResponse;
 
   public SAMLSession(@NotNull String SAMLRequestID, @NotNull RecordType recordType,

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SessionService.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SessionService.java
@@ -2,8 +2,8 @@ package it.pagopa.oneid.service;
 
 import it.pagopa.oneid.exception.SessionException;
 import it.pagopa.oneid.model.session.Session;
+import it.pagopa.oneid.model.session.enums.RecordType;
 import java.util.Optional;
-import org.opensaml.saml.saml2.core.Response;
 
 public interface SessionService<T extends Session> {
 
@@ -12,5 +12,5 @@ public interface SessionService<T extends Session> {
   Optional<T> getSession(String id, RecordType recordType)
       throws SessionException;
 
-  void setSAMLResponse(String samlRequestID, Response response);
+  void setSAMLResponse(String samlRequestID, String response) throws SessionException;
 }

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SessionService.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SessionService.java
@@ -9,7 +9,8 @@ public interface SessionService<T extends Session> {
 
   void saveSession(T session) throws SessionException;
 
-  Optional<T> getSession(String id);
+  Optional<T> getSession(String id, RecordType recordType)
+      throws SessionException;
 
   void setSAMLResponse(String samlRequestID, Response response);
 }

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SessionServiceImpl.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SessionServiceImpl.java
@@ -1,5 +1,6 @@
 package it.pagopa.oneid.service;
 
+import io.quarkus.logging.Log;
 import it.pagopa.oneid.connector.SessionConnectorImpl;
 import it.pagopa.oneid.exception.SessionException;
 import it.pagopa.oneid.model.session.Session;
@@ -16,9 +17,12 @@ public class SessionServiceImpl<T extends Session> implements SessionService<T> 
 
   @Override
   public void saveSession(T session) throws SessionException {
+    Log.debug("[SessionServiceImpl.saveSession] start");
     if (session != null) {
+      Log.debug("[SessionServiceImpl.saveSession] session successfully saved");
       sessionConnectorImpl.saveSession(session);
     } else {
+      Log.debug("[SessionServiceImpl.saveSession] save failed");
       throw new SessionException();
     }
   }

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SessionServiceImpl.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SessionServiceImpl.java
@@ -46,7 +46,7 @@ public class SessionServiceImpl<T extends Session> implements SessionService<T> 
   }
 
   @Override
-  public void setSAMLResponse(String samlRequestID, Response response) {
-
+  public void setSAMLResponse(String samlRequestID, String response) throws SessionException {
+    sessionConnectorImpl.updateSAMLSession(samlRequestID, response);
   }
 }

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SessionServiceImpl.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SessionServiceImpl.java
@@ -4,10 +4,10 @@ import io.quarkus.logging.Log;
 import it.pagopa.oneid.connector.SessionConnectorImpl;
 import it.pagopa.oneid.exception.SessionException;
 import it.pagopa.oneid.model.session.Session;
+import it.pagopa.oneid.model.session.enums.RecordType;
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import java.util.Optional;
-import org.opensaml.saml.saml2.core.Response;
 
 @Dependent
 public class SessionServiceImpl<T extends Session> implements SessionService<T> {
@@ -28,8 +28,21 @@ public class SessionServiceImpl<T extends Session> implements SessionService<T> 
   }
 
   @Override
-  public Optional<T> getSession(String id) {
-    return Optional.empty();
+  public Optional<T> getSession(String id, RecordType recordType)
+      throws SessionException {
+    Log.debug("[SessionServiceImpl.getSession] start");
+    Optional<T> result = sessionConnectorImpl.findSession(id, recordType);
+    // TODO add different exceptions for not found and expired sessions
+    if (result.isEmpty()) {
+      Log.debug(
+          "[SessionServiceImpl.getSession] session not found");
+      throw new SessionException();
+    } else {
+      Log.debug("[SessionServiceImpl.getSession] session successfully found");
+      return result;
+    }
+
+
   }
 
   @Override


### PR DESCRIPTION
This **PR** will introduce the following changes:

- OI-146: Implementation of `findSession` for SAMLSession record
- OI-147: Implementation of `updateSAMLSession` for SAMLSession record
- OI-148: Implementation of `saveSession` for OIDCSession record
- A refactor of `putItem` for SAMLSession record inside `saveSession` method  to make it consistent
- Added logs for the introduced methods