### PR TITLE
feat: Add cie support for metadata lambda

### DIFF
--- a/src/oneid/oneid-common/utils/src/main/java/it/pagopa/oneid/common/utils/SAMLUtilsConstants.java
+++ b/src/oneid/oneid-common/utils/src/main/java/it/pagopa/oneid/common/utils/SAMLUtilsConstants.java
@@ -21,10 +21,16 @@ public class SAMLUtilsConstants {
   public static String CONTACT_PERSON_GIVEN_NAME;
   public static String CONTACT_PERSON_EMAIL_ADDRESS;
   public static String CONTACT_PERSON_TELEPHONE_NUMBER;
-  public static String NAMESPACE_URI = "https://spid.gov.it/saml-extensions";
-  public static String NAMESPACE_PREFIX = "spid";
+  public static String NAMESPACE_URI_SPID = "https://spid.gov.it/saml-extensions";
+  public static String NAMESPACE_URI_CIE = "https://www.cartaidentita.interno.gov.it/saml-extensions";
+  public static String NAMESPACE_PREFIX_SPID = "spid";
+  public static String NAMESPACE_PREFIX_CIE = "cie";
   public static String LOCAL_NAME_IPA = "IPACode";
-  public static String IPA_CODE = "h_c501";
+  public static String LOCAL_NAME_VAT_NUMBER = "VATNumber";
+  public static String LOCAL_NAME_FISCAL_CODE = "FiscalCode";
+  public static String IPA_CODE = "5N2TR557";
+  public static String VAT_NUMBER = "IT15376371009";
+  public static String FISCAL_CODE = "15376371009";
   public static String LOCAL_NAME_PUBLIC = "Public";
   public static String NAME_FORMAT = "urn:oasis:names:tc:SAML:2.0:attrname-format:basic";
 

--- a/src/oneid/oneid-lambda-service-metadata/src/main/java/it/pagopa/oneid/SAMLUtilsExtendedMetadata.java
+++ b/src/oneid/oneid-lambda-service-metadata/src/main/java/it/pagopa/oneid/SAMLUtilsExtendedMetadata.java
@@ -3,11 +3,12 @@ package it.pagopa.oneid;
 import static it.pagopa.oneid.common.utils.SAMLUtilsConstants.ACS_URL;
 import static it.pagopa.oneid.common.utils.SAMLUtilsConstants.CONTACT_PERSON_COMPANY;
 import static it.pagopa.oneid.common.utils.SAMLUtilsConstants.CONTACT_PERSON_EMAIL_ADDRESS;
+import static it.pagopa.oneid.common.utils.SAMLUtilsConstants.FISCAL_CODE;
 import static it.pagopa.oneid.common.utils.SAMLUtilsConstants.IPA_CODE;
+import static it.pagopa.oneid.common.utils.SAMLUtilsConstants.LOCAL_NAME_FISCAL_CODE;
 import static it.pagopa.oneid.common.utils.SAMLUtilsConstants.LOCAL_NAME_IPA;
 import static it.pagopa.oneid.common.utils.SAMLUtilsConstants.LOCAL_NAME_PUBLIC;
-import static it.pagopa.oneid.common.utils.SAMLUtilsConstants.NAMESPACE_PREFIX;
-import static it.pagopa.oneid.common.utils.SAMLUtilsConstants.NAMESPACE_URI;
+import static it.pagopa.oneid.common.utils.SAMLUtilsConstants.LOCAL_NAME_VAT_NUMBER;
 import static it.pagopa.oneid.common.utils.SAMLUtilsConstants.NAME_FORMAT;
 import static it.pagopa.oneid.common.utils.SAMLUtilsConstants.ORGANIZATION_DISPLAY_NAME_XML_LANG;
 import static it.pagopa.oneid.common.utils.SAMLUtilsConstants.ORGANIZATION_NAME;
@@ -15,6 +16,7 @@ import static it.pagopa.oneid.common.utils.SAMLUtilsConstants.ORGANIZATION_NAME_
 import static it.pagopa.oneid.common.utils.SAMLUtilsConstants.ORGANIZATION_URL;
 import static it.pagopa.oneid.common.utils.SAMLUtilsConstants.ORGANIZATION_URL_XML_LANG;
 import static it.pagopa.oneid.common.utils.SAMLUtilsConstants.SLO_URL;
+import static it.pagopa.oneid.common.utils.SAMLUtilsConstants.VAT_NUMBER;
 import it.pagopa.oneid.common.model.Client;
 import it.pagopa.oneid.common.model.exception.SAMLUtilsException;
 import it.pagopa.oneid.common.utils.SAMLUtils;
@@ -137,12 +139,12 @@ public class SAMLUtilsExtendedMetadata extends SAMLUtils {
     return organizationURL;
   }
 
-  public static ContactPerson buildContactPerson() {
+  public static ContactPerson buildContactPerson(String namespacePrefix, String namespaceUri) {
     ContactPerson contactPerson = buildSAMLObject(ContactPerson.class);
     contactPerson.setCompany(buildCompany());
     contactPerson.setType(ContactPersonTypeEnumeration.OTHER);
     contactPerson.getEmailAddresses().add(buildEmailAddress());
-    contactPerson.setExtensions(buildExtensions());
+    contactPerson.setExtensions(buildExtensions(namespacePrefix, namespaceUri));
 
     return contactPerson;
   }
@@ -161,12 +163,24 @@ public class SAMLUtilsExtendedMetadata extends SAMLUtils {
     return emailAddress;
   }
 
-  public static Extensions buildExtensions() {
+  public static Extensions buildExtensions(String namespacePrefix, String namespaceUri) {
     Extensions extensions = buildSAMLObject(Extensions.class);
-    XSAny ipaCode = new XSAnyBuilder().buildObject(NAMESPACE_URI, LOCAL_NAME_IPA, NAMESPACE_PREFIX);
+
+    XSAny ipaCode = new XSAnyBuilder().buildObject(namespaceUri, LOCAL_NAME_IPA,
+        namespacePrefix);
     ipaCode.setTextContent(IPA_CODE);
     extensions.getUnknownXMLObjects().add(ipaCode);
-    XSAny pub = new XSAnyBuilder().buildObject(NAMESPACE_URI, LOCAL_NAME_PUBLIC, NAMESPACE_PREFIX);
+    XSAny vatNumber = new XSAnyBuilder().buildObject(namespaceUri, LOCAL_NAME_VAT_NUMBER,
+        namespacePrefix);
+    vatNumber.setTextContent(VAT_NUMBER);
+    extensions.getUnknownXMLObjects().add(vatNumber);
+    XSAny fiscalCode = new XSAnyBuilder().buildObject(namespaceUri, LOCAL_NAME_FISCAL_CODE,
+        namespacePrefix);
+    fiscalCode.setTextContent(FISCAL_CODE);
+    extensions.getUnknownXMLObjects().add(vatNumber);
+    XSAny pub = new XSAnyBuilder().buildObject(namespaceUri,
+        LOCAL_NAME_PUBLIC,
+        namespacePrefix);
     pub.setTextContent("");
     extensions.getUnknownXMLObjects().add(pub);
 

--- a/src/oneid/oneid-lambda-service-metadata/src/main/java/it/pagopa/oneid/ServiceMetadata.java
+++ b/src/oneid/oneid-lambda-service-metadata/src/main/java/it/pagopa/oneid/ServiceMetadata.java
@@ -9,17 +9,17 @@ import static it.pagopa.oneid.SAMLUtilsExtendedMetadata.buildOrganization;
 import static it.pagopa.oneid.SAMLUtilsExtendedMetadata.buildSPSSODescriptor;
 import static it.pagopa.oneid.SAMLUtilsExtendedMetadata.buildSingleLogoutService;
 import static it.pagopa.oneid.common.utils.SAMLUtils.buildSignature;
-import static it.pagopa.oneid.common.utils.SAMLUtilsConstants.NAMESPACE_PREFIX;
-import static it.pagopa.oneid.common.utils.SAMLUtilsConstants.NAMESPACE_URI;
 import static it.pagopa.oneid.common.utils.SAMLUtilsConstants.SERVICE_PROVIDER_URI;
 import it.pagopa.oneid.common.model.Client;
 import it.pagopa.oneid.common.model.exception.OneIdentityException;
 import it.pagopa.oneid.common.model.exception.SAMLUtilsException;
 import it.pagopa.oneid.common.utils.SAMLUtils;
 import it.pagopa.oneid.common.utils.SAMLUtilsConstants;
+import it.pagopa.oneid.enums.IdType;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -67,9 +67,9 @@ public class ServiceMetadata {
   }
 
   @GET
-  @Path("/metadata")
+  @Path("/{id_type}/metadata")
   @Produces(MediaType.APPLICATION_XML)
-  public Response metadata() throws OneIdentityException {
+  public Response metadata(@PathParam("id_type") IdType idType) throws OneIdentityException {
 
     EntityDescriptor entityDescriptor = SAMLUtils.buildSAMLObject(EntityDescriptor.class);
     entityDescriptor.setEntityID(SERVICE_PROVIDER_URI);
@@ -86,10 +86,12 @@ public class ServiceMetadata {
     }
 
     entityDescriptor.setOrganization(buildOrganization());
-    entityDescriptor.getContactPersons().add(buildContactPerson());
+    entityDescriptor.getContactPersons()
+        .add(buildContactPerson(idType.getNamespacePrefix(), idType.getNamespaceUri()));
     entityDescriptor.getRoleDescriptors().add(spssoDescriptor);
     entityDescriptor.getNamespaceManager()
-        .registerNamespaceDeclaration(new Namespace(NAMESPACE_URI, NAMESPACE_PREFIX));
+        .registerNamespaceDeclaration(
+            new Namespace(idType.getNamespaceUri(), idType.getNamespacePrefix()));
 
     Signature signature = buildSignature(entityDescriptor);
     entityDescriptor.setSignature(signature);

--- a/src/oneid/oneid-lambda-service-metadata/src/main/java/it/pagopa/oneid/enums/IdType.java
+++ b/src/oneid/oneid-lambda-service-metadata/src/main/java/it/pagopa/oneid/enums/IdType.java
@@ -1,0 +1,26 @@
+package it.pagopa.oneid.enums;
+
+import it.pagopa.oneid.common.utils.SAMLUtilsConstants;
+
+public enum IdType {
+  spid(SAMLUtilsConstants.NAMESPACE_PREFIX_SPID, SAMLUtilsConstants.NAMESPACE_URI_SPID),
+  cie(SAMLUtilsConstants.NAMESPACE_PREFIX_CIE, SAMLUtilsConstants.NAMESPACE_URI_CIE);
+
+  private final String namespacePrefix;
+  private final String namespaceUri;
+
+
+  IdType(String namespacePrefix, String namespaceUri) {
+    this.namespacePrefix = namespacePrefix;
+    this.namespaceUri = namespaceUri;
+  }
+
+  public String getNamespacePrefix() {
+    return namespacePrefix;
+  }
+
+  public String getNamespaceUri() {
+    return namespaceUri;
+  }
+
+}


### PR DESCRIPTION
This **PR** introduces support for **CIE**, including a route that returns the metadata for the selected Identity type (**CIE** or **SPID**) depending on the path parameter selected. Also added the `Extensions` for metadata with correct attributes 