### PR TITLE
Feat: OI 166 aggiunta parametri obbligatori ad id token secondo rfc

### DIFF
--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/OIDCService.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/OIDCService.java
@@ -19,7 +19,8 @@ public interface OIDCService {
 
   AuthorizationResponse getAuthorizationResponse(AuthorizationRequest authorizationRequest);
 
-  TokenDataDTO getOIDCTokens(String client_id, List<AttributeDTO> attributeDTOList, String nonce);
+  TokenDataDTO getOIDCTokens(String requestId, String clientId, List<AttributeDTO> attributeDTOList,
+      String nonce);
 
   void authorizeClient(String clientId, String secret);
 

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/OIDCService.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/OIDCService.java
@@ -19,7 +19,7 @@ public interface OIDCService {
 
   AuthorizationResponse getAuthorizationResponse(AuthorizationRequest authorizationRequest);
 
-  TokenDataDTO getOIDCTokens(List<AttributeDTO> attributeDTOList, String nonce);
+  TokenDataDTO getOIDCTokens(String client_id, List<AttributeDTO> attributeDTOList, String nonce);
 
   void authorizeClient(String clientId, String secret);
 

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/OIDCServiceImpl.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/OIDCServiceImpl.java
@@ -185,7 +185,8 @@ public class OIDCServiceImpl implements OIDCService {
   }
 
   @Override
-  public TokenDataDTO getOIDCTokens(String client_id, List<AttributeDTO> attributeDTOList,
+  public TokenDataDTO getOIDCTokens(String requestId, String clientId,
+      List<AttributeDTO> attributeDTOList,
       String nonce) {
     Log.debug(("start"));
 
@@ -194,7 +195,8 @@ public class OIDCServiceImpl implements OIDCService {
     AccessToken accessToken = new BearerAccessToken(VALID_TIME_ACCESS_TOKEN_MIN * 60L, null);
 
     //Create signed JWT ID token
-    String signedJWTString = oidcUtils.createSignedJWT(client_id, attributeDTOList, nonce);
+    String signedJWTString = oidcUtils.createSignedJWT(requestId, clientId, attributeDTOList,
+        nonce);
     SignedJWT signedJWTIDToken;
     try {
       signedJWTIDToken = SignedJWT.parse(signedJWTString);

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/utils/OIDCUtils.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/utils/OIDCUtils.java
@@ -24,10 +24,13 @@ public class OIDCUtils {
   @Inject
   KMSConnectorImpl kmsConnectorImpl;
 
-  private static JWTClaimsSet buildJWTClaimsSet(List<AttributeDTO> attributeDTOList, String nonce) {
+  private static JWTClaimsSet buildJWTClaimsSet(String client_id,
+      List<AttributeDTO> attributeDTOList, String nonce) {
     JWTClaimsSet.Builder jwtClaimsSet = new JWTClaimsSet.Builder()
         .subject(SERVICE_PROVIDER_URI)
         .issuer(SERVICE_PROVIDER_URI)
+        .audience(client_id)
+        .issueTime(new Date())
         .claim("nonce", nonce)
         .expirationTime(new Date(new Date().getTime() + (long) VALID_TIME_JWT_MIN * 60 * 1000));
 
@@ -37,7 +40,8 @@ public class OIDCUtils {
     return jwtClaimsSet.build();
   }
 
-  public String createSignedJWT(List<AttributeDTO> attributeDTOList, String nonce) {
+  public String createSignedJWT(String client_id, List<AttributeDTO> attributeDTOList,
+      String nonce) {
     // Prepare header for JWT
     JWSHeader jwsHeader = new JWSHeader.Builder(JWSAlgorithm.RS256)
         .type(JOSEObjectType.JWT)
@@ -47,7 +51,8 @@ public class OIDCUtils {
 
     // Prepare claims set for JWT
 
-    byte[] payloadBytes = buildJWTClaimsSet(attributeDTOList, nonce).toPayload().toBytes();
+    byte[] payloadBytes = buildJWTClaimsSet(client_id, attributeDTOList, nonce).toPayload()
+        .toBytes();
     byte[] encodedPayload = base64UrlEncoder.encodeToString(payloadBytes).getBytes();
 
     // Create a signature with base64 encoded header and payload

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/utils/OIDCUtils.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/utils/OIDCUtils.java
@@ -24,12 +24,12 @@ public class OIDCUtils {
   @Inject
   KMSConnectorImpl kmsConnectorImpl;
 
-  private static JWTClaimsSet buildJWTClaimsSet(String client_id,
+  private static JWTClaimsSet buildJWTClaimsSet(String requestId, String clientId,
       List<AttributeDTO> attributeDTOList, String nonce) {
     JWTClaimsSet.Builder jwtClaimsSet = new JWTClaimsSet.Builder()
-        .subject(SERVICE_PROVIDER_URI)
+        .subject(requestId)
         .issuer(SERVICE_PROVIDER_URI)
-        .audience(client_id)
+        .audience(clientId)
         .issueTime(new Date())
         .claim("nonce", nonce)
         .expirationTime(new Date(new Date().getTime() + (long) VALID_TIME_JWT_MIN * 60 * 1000));
@@ -40,7 +40,8 @@ public class OIDCUtils {
     return jwtClaimsSet.build();
   }
 
-  public String createSignedJWT(String client_id, List<AttributeDTO> attributeDTOList,
+  public String createSignedJWT(String requestId, String clientId,
+      List<AttributeDTO> attributeDTOList,
       String nonce) {
     // Prepare header for JWT
     JWSHeader jwsHeader = new JWSHeader.Builder(JWSAlgorithm.RS256)
@@ -51,7 +52,8 @@ public class OIDCUtils {
 
     // Prepare claims set for JWT
 
-    byte[] payloadBytes = buildJWTClaimsSet(client_id, attributeDTOList, nonce).toPayload()
+    byte[] payloadBytes = buildJWTClaimsSet(requestId, clientId, attributeDTOList,
+        nonce).toPayload()
         .toBytes();
     byte[] encodedPayload = base64UrlEncoder.encodeToString(payloadBytes).getBytes();
 

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/OIDCController.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/OIDCController.java
@@ -267,7 +267,7 @@ public class OIDCController {
         .getAssertions()
         .getFirst();
 
-    TokenDataDTO tokenDataDTO = oidcServiceImpl.getOIDCTokens(
+    TokenDataDTO tokenDataDTO = oidcServiceImpl.getOIDCTokens(clientId,
         samlServiceImpl.getAttributesFromSAMLAssertion(assertion),
         session.getAuthorizationRequestDTOExtended().getNonce());
 

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/OIDCController.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/OIDCController.java
@@ -267,7 +267,7 @@ public class OIDCController {
         .getAssertions()
         .getFirst();
 
-    TokenDataDTO tokenDataDTO = oidcServiceImpl.getOIDCTokens(clientId,
+    TokenDataDTO tokenDataDTO = oidcServiceImpl.getOIDCTokens(session.getSamlRequestID(), clientId,
         samlServiceImpl.getAttributesFromSAMLAssertion(assertion),
         session.getAuthorizationRequestDTOExtended().getNonce());
 

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/dto/TokenDataDTO.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/dto/TokenDataDTO.java
@@ -21,7 +21,7 @@ public class TokenDataDTO {
 
   @JsonProperty("expires_in")
   @NotNull
-  String expiresIn;
+  long expiresIn;
 
   @JsonProperty("refresh_token")
   String refreshToken;


### PR DESCRIPTION
This **PR** adds `iat` and `aud` attributes in `IDToken` parameter returned by `oidc/token` POST.

It also sets `sub` with the `SAMLRequestID` of the session to meet [OIDC RFC expectations](https://openid.net/specs/openid-connect-core-1_0.html#IDToken)