### PR TITLE
feat: add Token Request Error response mapping to meet OIDC RFC specification

### DIFF
--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/InvalidClientException.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/InvalidClientException.java
@@ -1,0 +1,16 @@
+package it.pagopa.oneid.exception;
+
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import lombok.Getter;
+
+@Getter
+public class InvalidClientException extends RuntimeException {
+
+  private final String errorMessage;
+
+  public InvalidClientException(String errorMessage) {
+    super(OAuth2Error.INVALID_CLIENT_CODE);
+    this.errorMessage = errorMessage;
+  }
+
+}

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/InvalidGrantException.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/InvalidGrantException.java
@@ -1,0 +1,11 @@
+package it.pagopa.oneid.exception;
+
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+
+public class InvalidGrantException extends RuntimeException {
+
+  public InvalidGrantException() {
+    super(OAuth2Error.INVALID_GRANT_CODE);
+  }
+
+}

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/InvalidRequestMalformedHeaderAuthorizationException.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/InvalidRequestMalformedHeaderAuthorizationException.java
@@ -1,0 +1,10 @@
+package it.pagopa.oneid.exception;
+
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+
+public class InvalidRequestMalformedHeaderAuthorizationException extends RuntimeException {
+
+  public InvalidRequestMalformedHeaderAuthorizationException() {
+    super(OAuth2Error.INVALID_REQUEST_CODE);
+  }
+}

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/UnsupportedGrantTypeException.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/UnsupportedGrantTypeException.java
@@ -1,0 +1,11 @@
+package it.pagopa.oneid.exception;
+
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+
+public class UnsupportedGrantTypeException extends RuntimeException {
+
+  public UnsupportedGrantTypeException() {
+    super(OAuth2Error.UNSUPPORTED_GRANT_TYPE_CODE);
+  }
+
+}

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/OIDCServiceImpl.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/OIDCServiceImpl.java
@@ -26,7 +26,7 @@ import it.pagopa.oneid.common.model.dto.SecretDTO;
 import it.pagopa.oneid.common.utils.HASHUtils;
 import it.pagopa.oneid.common.utils.SAMLUtilsConstants;
 import it.pagopa.oneid.connector.KMSConnectorImpl;
-import it.pagopa.oneid.exception.OIDCAuthorizationException;
+import it.pagopa.oneid.exception.InvalidClientException;
 import it.pagopa.oneid.exception.OIDCSignJWTException;
 import it.pagopa.oneid.model.dto.AttributeDTO;
 import it.pagopa.oneid.model.dto.AuthorizationRequestDTO;
@@ -221,15 +221,15 @@ public class OIDCServiceImpl implements OIDCService {
     Log.debug("start");
     if (clientsMap.get(clientId) == null) {
       Log.debug("client not found");
-      throw new OIDCAuthorizationException();
+      throw new InvalidClientException("Client ID not valid");
     }
 
     SecretDTO secretDTO = clientConnectorImpl.getClientSecret(clientId)
-        .orElseThrow(OIDCAuthorizationException::new);
+        .orElseThrow(() -> new InvalidClientException("Client secret not found"));
 
     if (!HASHUtils.validateSecret(clientSecret, secretDTO.getSalt(), secretDTO.getSecret())) {
       Log.debug("client secret not valid");
-      throw new OIDCAuthorizationException();
+      throw new InvalidClientException("Client secret not valid");
     }
   }
 }

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/dto/TokenRequestErrorDTO.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/dto/TokenRequestErrorDTO.java
@@ -1,0 +1,19 @@
+package it.pagopa.oneid.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.jackson.Jacksonized;
+
+@Getter
+@Builder
+@Jacksonized
+@JsonPropertyOrder({"error", "error_description"})
+public class TokenRequestErrorDTO {
+
+  private String error;
+
+  @JsonProperty("error_description")
+  private String errorDescription;
+}


### PR DESCRIPTION
This **PR** adds `Token Request` error response mapping to meet [OIDC RFC Spec.](https://openid.net/specs/openid-connect-core-1_0.html#TokenErrorResponse)