### PR TITLE
Chore: replace List  parameters with Set in Client Registration

### DIFF
--- a/src/oneid/oneid-common/connector/src/main/java/it/pagopa/oneid/common/connector/ClientConnectorImpl.java
+++ b/src/oneid/oneid-common/connector/src/main/java/it/pagopa/oneid/common/connector/ClientConnectorImpl.java
@@ -77,7 +77,7 @@ public class ClientConnectorImpl implements ClientConnector {
   @Override
   public Optional<Client> getClientById(String clientId) {
     Log.debug("start");
-    return Optional.of(
+    return Optional.ofNullable(
         clientMapper.getItem(Key.builder().partitionValue(clientId).build()));
   }
 

--- a/src/oneid/oneid-common/model/src/main/java/it/pagopa/oneid/common/model/Client.java
+++ b/src/oneid/oneid-common/model/src/main/java/it/pagopa/oneid/common/model/Client.java
@@ -3,7 +3,7 @@ package it.pagopa.oneid.common.model;
 import it.pagopa.oneid.common.model.enums.AuthLevel;
 import it.pagopa.oneid.common.model.enums.converter.AuthLevelConverter;
 import jakarta.validation.constraints.NotNull;
-import java.util.List;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -30,10 +30,10 @@ public class Client {
   private String friendlyName;
 
   @NotNull
-  private List<String> callbackURI;
+  private Set<String> callbackURI;
 
   @NotNull
-  private List<String> requestedParameters;
+  private Set<String> requestedParameters;
 
 
   @Getter(onMethod_ = @DynamoDbConvertedBy(AuthLevelConverter.class))

--- a/src/oneid/oneid-common/model/src/main/java/it/pagopa/oneid/common/model/ClientExtended.java
+++ b/src/oneid/oneid-common/model/src/main/java/it/pagopa/oneid/common/model/ClientExtended.java
@@ -3,7 +3,7 @@ package it.pagopa.oneid.common.model;
 import it.pagopa.oneid.common.model.dto.SecretDTO;
 import it.pagopa.oneid.common.model.enums.AuthLevel;
 import jakarta.validation.constraints.NotNull;
-import java.util.List;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -26,8 +26,8 @@ public class ClientExtended extends Client {
   private String salt;
 
   public ClientExtended(@NotNull String clientId, @NotNull String friendlyName,
-      @NotNull List<String> callbackURI,
-      @NotNull List<String> requestedParameters, @NotNull AuthLevel authLevel,
+      @NotNull Set<String> callbackURI,
+      @NotNull Set<String> requestedParameters, @NotNull AuthLevel authLevel,
       @NotNull int acsIndex, @NotNull int attributeIndex, @NotNull boolean isActive,
       String secret, String salt, long clientIdIssuedAt, String logoUri) {
     super(clientId, friendlyName, callbackURI, requestedParameters, authLevel, acsIndex,

--- a/src/oneid/oneid-lambda-client-registration/src/main/java/it/pagopa/oneid/model/dto/ClientMetadataDTO.java
+++ b/src/oneid/oneid-lambda-client-registration/src/main/java/it/pagopa/oneid/model/dto/ClientMetadataDTO.java
@@ -5,7 +5,7 @@ import it.pagopa.oneid.common.model.enums.Identifier;
 import it.pagopa.oneid.web.validator.annotations.AuthLevelCheck;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
-import java.util.List;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -25,7 +25,7 @@ public class ClientMetadataDTO {
   @JsonProperty("redirect_uris")
   @RestForm("redirect_uris")
   @Parameter(explode = Explode.TRUE, style = ParameterStyle.FORM)
-  private List<String> redirectUris; //Client.callbackURI
+  private Set<String> redirectUris; //Client.callbackURI
 
   @NotBlank
   @JsonProperty("client_name")
@@ -40,13 +40,13 @@ public class ClientMetadataDTO {
   @RestForm("default_acr_values")
   @Parameter(explode = Explode.TRUE, style = ParameterStyle.FORM)
   @AuthLevelCheck
-  private List<String> defaultAcrValues;
+  private Set<String> defaultAcrValues;
 
   @NotEmpty
   @JsonProperty("saml_requested_attributes")
   @RestForm("saml_requested_attributes")
   @Parameter(explode = Explode.TRUE, style = ParameterStyle.FORM)
-  private List<Identifier> samlRequestedAttributes;
+  private Set<Identifier> samlRequestedAttributes;
 
 
   public ClientMetadataDTO(ClientMetadataDTO clientMetadataDTO) {

--- a/src/oneid/oneid-lambda-client-registration/src/main/java/it/pagopa/oneid/service/ClientRegistrationServiceImpl.java
+++ b/src/oneid/oneid-lambda-client-registration/src/main/java/it/pagopa/oneid/service/ClientRegistrationServiceImpl.java
@@ -23,7 +23,7 @@ import jakarta.inject.Inject;
 import java.net.URI;
 import java.security.NoSuchAlgorithmException;
 import java.util.Comparator;
-import java.util.List;
+import java.util.Set;
 
 @ApplicationScoped
 public class ClientRegistrationServiceImpl implements ClientRegistrationService {
@@ -98,8 +98,9 @@ public class ClientRegistrationServiceImpl implements ClientRegistrationService 
     clientConnector.saveClientIfNotExists(clientExtended);
 
     // 6. Overwrite clientRegistrationRequestDTO.defaultAcrValues with only its first value
-    clientRegistrationRequestDTO.setDefaultAcrValues(List.of(
-        clientRegistrationRequestDTO.getDefaultAcrValues().getFirst()));
+    clientRegistrationRequestDTO.setDefaultAcrValues(Set.of(
+        clientRegistrationRequestDTO.getDefaultAcrValues().stream().findFirst()
+            .orElseThrow(ClientRegistrationServiceException::new)));
 
     // 7. create and return ClientRegistrationResponseDTO
     Log.debug("end");

--- a/src/oneid/oneid-lambda-client-registration/src/main/java/it/pagopa/oneid/web/validator/AuthLevelValidator.java
+++ b/src/oneid/oneid-lambda-client-registration/src/main/java/it/pagopa/oneid/web/validator/AuthLevelValidator.java
@@ -4,10 +4,10 @@ import it.pagopa.oneid.common.model.enums.AuthLevel;
 import it.pagopa.oneid.web.validator.annotations.AuthLevelCheck;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
-import java.util.List;
+import java.util.Set;
 
 public class AuthLevelValidator implements
-    ConstraintValidator<AuthLevelCheck, List<String>> {
+    ConstraintValidator<AuthLevelCheck, Set<String>> {
 
 
   @Override
@@ -16,7 +16,7 @@ public class AuthLevelValidator implements
   }
 
   @Override
-  public boolean isValid(List<String> acr, ConstraintValidatorContext constraintValidatorContext) {
+  public boolean isValid(Set<String> acr, ConstraintValidatorContext constraintValidatorContext) {
 
     if (acr != null && !acr.isEmpty()) {
       return acr.stream().noneMatch(authLevel -> AuthLevel.authLevelFromValue(authLevel) == null);


### PR DESCRIPTION
This **PR** adds the following updates:
- Replacing `List` type with `Set` in Client Registration to ensure uniqueness
- Replace `Optional.of` with `Optional.ofNullable` in ClientConnector to correctly map `Unauthorized request`