### PR TITLE
Fix: add Basic Auth URL Encoding support on POST oidc/token endpoint

### DIFF
--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/OIDCController.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/OIDCController.java
@@ -39,6 +39,8 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
@@ -264,8 +266,8 @@ public class OIDCController {
     try {
       decodedBytes = Base64.getDecoder().decode(authorization);
       decodedString = new String(decodedBytes);
-      clientId = decodedString.split(":")[0];
-      clientSecret = decodedString.split(":")[1];
+      clientId = URLDecoder.decode(decodedString.split(":")[0], StandardCharsets.UTF_8);
+      clientSecret = URLDecoder.decode(decodedString.split(":")[1], StandardCharsets.UTF_8);
     } catch (IllegalArgumentException | ArrayIndexOutOfBoundsException e) {
       throw new InvalidRequestMalformedHeaderAuthorizationException();
     }

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/OIDCController.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/OIDCController.java
@@ -39,6 +39,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -266,9 +267,12 @@ public class OIDCController {
     try {
       decodedBytes = Base64.getDecoder().decode(authorization);
       decodedString = new String(decodedBytes);
-      clientId = URLDecoder.decode(decodedString.split(":")[0], StandardCharsets.UTF_8);
-      clientSecret = URLDecoder.decode(decodedString.split(":")[1], StandardCharsets.UTF_8);
-    } catch (IllegalArgumentException | ArrayIndexOutOfBoundsException e) {
+      clientId = URLDecoder.decode(decodedString.split(":")[0], StandardCharsets.UTF_8.toString());
+      System.out.println("Decoded client id: " + clientId);
+      clientSecret = URLDecoder.decode(decodedString.split(":")[1],
+          StandardCharsets.UTF_8.toString());
+    } catch (IllegalArgumentException | ArrayIndexOutOfBoundsException |
+             UnsupportedEncodingException e) {
       throw new InvalidRequestMalformedHeaderAuthorizationException();
     }
 

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/OIDCController.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/OIDCController.java
@@ -268,7 +268,6 @@ public class OIDCController {
       decodedBytes = Base64.getDecoder().decode(authorization);
       decodedString = new String(decodedBytes);
       clientId = URLDecoder.decode(decodedString.split(":")[0], StandardCharsets.UTF_8.toString());
-      System.out.println("Decoded client id: " + clientId);
       clientSecret = URLDecoder.decode(decodedString.split(":")[1],
           StandardCharsets.UTF_8.toString());
     } catch (IllegalArgumentException | ArrayIndexOutOfBoundsException |


### PR DESCRIPTION
This **PR** adds support for URL Encoding in Basic Authentication Header for POST `oidc/token` endpoint