### PR TITLE
chore: add conditional not blank for IPAddress in authorize endpoint

### DIFF
--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/dto/AuthorizationRequestDTOExtendedGet.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/dto/AuthorizationRequestDTOExtendedGet.java
@@ -2,6 +2,7 @@ package it.pagopa.oneid.web.dto;
 
 import it.pagopa.oneid.model.session.enums.ResponseType;
 import it.pagopa.oneid.web.validator.annotations.AuthenticationRequestCheck;
+import it.pagopa.oneid.web.validator.annotations.ConditionalNotBlank;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -14,24 +15,31 @@ import org.jboss.resteasy.reactive.RestQuery;
 public class AuthorizationRequestDTOExtendedGet {
 
   @HeaderParam("X-Forwarded-For")
-  @NotBlank
+  @ConditionalNotBlank(field = "ipAddress")
   String ipAddress;
+
   @NotBlank
   @RestQuery
   private String idp;
+
   @NotBlank
   @Size(max = 255)
   @RestQuery("client_id")
   private String clientId;
+
   @NotNull
   @RestQuery("response_type")
   private ResponseType responseType;
+
   @RestQuery("redirect_uri")
   private String redirectUri;
+
   @RestQuery
   private String scope;
+
   @RestQuery
   private String nonce;
+
   @RestQuery
   private String state;
 

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/dto/AuthorizationRequestDTOExtendedPost.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/dto/AuthorizationRequestDTOExtendedPost.java
@@ -2,6 +2,7 @@ package it.pagopa.oneid.web.dto;
 
 import it.pagopa.oneid.model.session.enums.ResponseType;
 import it.pagopa.oneid.web.validator.annotations.AuthenticationRequestCheck;
+import it.pagopa.oneid.web.validator.annotations.ConditionalNotBlank;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -14,8 +15,9 @@ import org.jboss.resteasy.reactive.RestForm;
 public class AuthorizationRequestDTOExtendedPost {
 
   @HeaderParam("X-Forwarded-For")
-  @NotBlank
+  @ConditionalNotBlank(field = "ipAddress")
   String ipAddress;
+
   @NotBlank
   @RestForm
   private String idp;

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/validator/ConditionalNotBlankValidator.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/validator/ConditionalNotBlankValidator.java
@@ -1,0 +1,31 @@
+package it.pagopa.oneid.web.validator;
+
+import io.quarkus.logging.Log;
+import io.quarkus.runtime.configuration.ConfigUtils;
+import it.pagopa.oneid.web.validator.annotations.ConditionalNotBlank;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.apache.commons.lang3.StringUtils;
+
+public class ConditionalNotBlankValidator implements
+    ConstraintValidator<ConditionalNotBlank, String> {
+
+  String field;
+
+  @Override
+  public void initialize(ConditionalNotBlank constraintAnnotation) {
+    ConstraintValidator.super.initialize(constraintAnnotation);
+    this.field = constraintAnnotation.field();
+  }
+
+  @Override
+  public boolean isValid(String o, ConstraintValidatorContext constraintValidatorContext) {
+    if (!ConfigUtils.getProfiles().contains("dev")) {
+      if (o == null || StringUtils.isBlank(o)) {
+        Log.error(this.field + " must not be blank");
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/validator/annotations/ConditionalNotBlank.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/validator/annotations/ConditionalNotBlank.java
@@ -1,0 +1,25 @@
+package it.pagopa.oneid.web.validator.annotations;
+
+import it.pagopa.oneid.web.validator.ConditionalNotBlankValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ConditionalNotBlankValidator.class)
+public @interface ConditionalNotBlank {
+
+  String message() default "Field must not be blank if the environment is not dev";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+
+  String value() default "";
+
+  String field();
+}


### PR DESCRIPTION
This **PR** adds custom `ConditionalNotBlank` annotation for `IPAddress ` field in `AuthorizationRequestDTOGET` and `AuthorizationRequestDTOPost` for `/oidc/authorize` endpoint to avoid Constraint Validation when application is running as quarkus dev profile. 