### PR TITLE
Test: add dynamodb local instance junit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,4 +82,4 @@ src/oneid/oneid-ecs-core/src/main/webui/build
 src/oneid/oneid-ecs-core/.quinoa
 
 # ignore local dynamodb metadata files
-*/dynamodb-local-metadata.json
+/src/oneid/oneid-ecs-core/dynamodb-local-metadata.json

--- a/.gitignore
+++ b/.gitignore
@@ -81,4 +81,5 @@ src/oneid/oneid-ecs-core/src/main/webui/node_modules
 src/oneid/oneid-ecs-core/src/main/webui/build
 src/oneid/oneid-ecs-core/.quinoa
 
-
+# ignore local dynamodb metadata files
+*/dynamodb-local-metadata.json

--- a/src/oneid/oneid-ecs-core/pom.xml
+++ b/src/oneid/oneid-ecs-core/pom.xml
@@ -209,7 +209,8 @@
                         <configuration>
                             <includeScope>test</includeScope>
                             <includeTypes>so,dll,dylib</includeTypes>
-                            <outputDirectory>${project.basedir}/native-libs</outputDirectory>
+                            <outputDirectory>${project.basedir}/target/test/native-libs
+                            </outputDirectory>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/oneid/oneid-ecs-core/pom.xml
+++ b/src/oneid/oneid-ecs-core/pom.xml
@@ -138,6 +138,23 @@
             <artifactId>quarkus-jacoco</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>DynamoDBLocal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.github.ganadist.sqlite4java</groupId>
+            <artifactId>libsqlite4java-osx-aarch64</artifactId>
+            <scope>test</scope>
+            <type>dylib</type>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -178,6 +195,27 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.10</version>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeScope>test</includeScope>
+                            <includeTypes>so,dll,dylib</includeTypes>
+                            <outputDirectory>${project.basedir}/native-libs</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
+
     </build>
 </project>

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/connector/SessionConnectorImplTest.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/connector/SessionConnectorImplTest.java
@@ -1,29 +1,89 @@
 package it.pagopa.oneid.connector;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import com.amazonaws.services.dynamodbv2.local.main.ServerRunner;
+import com.amazonaws.services.dynamodbv2.local.server.DynamoDBProxyServer;
 import io.quarkus.test.junit.QuarkusTest;
 import it.pagopa.oneid.model.session.SAMLSession;
+import it.pagopa.oneid.model.session.enums.RecordType;
+import it.pagopa.oneid.web.dto.AuthorizationRequestDTOExtended;
 import jakarta.inject.Inject;
-import org.junit.jupiter.api.Disabled;
+import lombok.SneakyThrows;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 
 @QuarkusTest
 class SessionConnectorImplTest {
 
+  private static DynamoDBProxyServer server;
+
+  private static DynamoDbTable<SAMLSession> samlSessionMapper;
+  
   @Inject
   SessionConnectorImpl<SAMLSession> samlSessionConnectorImpl;
 
+  @Inject
+  DynamoDbEnhancedClient dynamoDbEnhancedClient;
+
+  @Inject
+  @ConfigProperty(name = "sessions_table_name")
+  String TABLE_NAME;
+
+  @SneakyThrows
+  @Inject
+  public SessionConnectorImplTest() {
+    System.setProperty("sqlite4java.library.path", "target/test/native-libs");
+
+  }
+
+  @BeforeAll
+  public static void setupClass() throws Exception {
+    String port = "8000";
+
+    server = ServerRunner.createServerFromCommandLineArgs(
+        new String[]{"-inMemory", "-port", port});
+    server.start();
+  }
+
+  @AfterAll
+  public static void teardownClass() throws Exception {
+    server.stop();
+  }
+
+  @BeforeEach
+  public void beforeEach() {
+    samlSessionMapper = dynamoDbEnhancedClient.table(TABLE_NAME,
+        TableSchema.fromBean(SAMLSession.class));
+    samlSessionMapper.createTable();
+  }
+
+  @AfterEach
+  public void afterEach() {
+    samlSessionMapper = dynamoDbEnhancedClient.table(TABLE_NAME,
+        TableSchema.fromBean(SAMLSession.class));
+    samlSessionMapper.deleteTable();
+  }
+
   @Test
-  @Disabled
-    //TODO implement this
   void saveSAMLSession() {
 
     //given
-    //SAMLSession session = new SAMLSession();
+    SAMLSession session = new SAMLSession("id", RecordType.SAML, 0, 0, "test",
+        AuthorizationRequestDTOExtended.builder().build());
 
-    //Executable executable = () -> samlSessionConnectorImpl.saveSession(session);
+    Executable executable = () -> samlSessionConnectorImpl.saveSessionIfNotExists(session);
 
     //then
-    //assertDoesNotThrow(executable);
+    assertDoesNotThrow(executable);
 
   }
+
 }

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/connector/SessionConnectorImplTest.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/connector/SessionConnectorImplTest.java
@@ -1,13 +1,21 @@
 package it.pagopa.oneid.connector;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.amazonaws.services.dynamodbv2.local.main.ServerRunner;
 import com.amazonaws.services.dynamodbv2.local.server.DynamoDBProxyServer;
 import io.quarkus.test.junit.QuarkusTest;
+import it.pagopa.oneid.connector.model.DummySession;
+import it.pagopa.oneid.exception.SessionException;
+import it.pagopa.oneid.model.session.AccessTokenSession;
+import it.pagopa.oneid.model.session.OIDCSession;
 import it.pagopa.oneid.model.session.SAMLSession;
 import it.pagopa.oneid.model.session.enums.RecordType;
 import it.pagopa.oneid.web.dto.AuthorizationRequestDTOExtended;
 import jakarta.inject.Inject;
+import java.time.Instant;
 import lombok.SneakyThrows;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterAll;
@@ -19,16 +27,29 @@ import org.junit.jupiter.api.function.Executable;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.CreateTableEnhancedRequest;
+import software.amazon.awssdk.enhanced.dynamodb.model.EnhancedGlobalSecondaryIndex;
+import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
 
 @QuarkusTest
 class SessionConnectorImplTest {
 
   private static DynamoDBProxyServer server;
 
-  private static DynamoDbTable<SAMLSession> samlSessionMapper;
-  
+  private static DynamoDbTable<OIDCSession> oidcSessionMapper;
+
   @Inject
   SessionConnectorImpl<SAMLSession> samlSessionConnectorImpl;
+
+  @Inject
+  SessionConnectorImpl<OIDCSession> oidcSessionConnectorImpl;
+
+  @Inject
+  SessionConnectorImpl<AccessTokenSession> accessTokenSessionConnectorImpl;
+
+  @Inject
+  SessionConnectorImpl<DummySession> dummySessionConnectorImpl;
 
   @Inject
   DynamoDbEnhancedClient dynamoDbEnhancedClient;
@@ -36,6 +57,10 @@ class SessionConnectorImplTest {
   @Inject
   @ConfigProperty(name = "sessions_table_name")
   String TABLE_NAME;
+
+  @Inject
+  @ConfigProperty(name = "sessions_g_idx")
+  String IDX_NAME;
 
   @SneakyThrows
   @Inject
@@ -60,30 +85,347 @@ class SessionConnectorImplTest {
 
   @BeforeEach
   public void beforeEach() {
-    samlSessionMapper = dynamoDbEnhancedClient.table(TABLE_NAME,
-        TableSchema.fromBean(SAMLSession.class));
-    samlSessionMapper.createTable();
+    // Here we create the -> {sessions_table_name} table with -> {sessions_g_idx} index
+
+    // We don't need to create a table for each mapper because it is the same for each one -> {sessions_table_name}
+    // We use oidcSessionMapper (accessTokenSessionMapper would be the same) because it also contains information about GlobalSecondaryIndex -> {sessions_g_idx}
+    oidcSessionMapper = dynamoDbEnhancedClient.table(TABLE_NAME,
+        TableSchema.fromBean(OIDCSession.class));
+
+    CreateTableEnhancedRequest createTableEnhancedRequest = CreateTableEnhancedRequest.builder()
+        .provisionedThroughput(
+            ProvisionedThroughput.builder()
+                .readCapacityUnits(10L)
+                .writeCapacityUnits(10L)
+                .build())
+        .globalSecondaryIndices(
+            EnhancedGlobalSecondaryIndex.builder()
+                .indexName(IDX_NAME)
+                .projection(p -> p.projectionType(ProjectionType.ALL))
+                .provisionedThroughput(ProvisionedThroughput.builder()
+                    .readCapacityUnits(10L)
+                    .writeCapacityUnits(10L)
+                    .build())
+                .build())
+        .build();
+    oidcSessionMapper.createTable(createTableEnhancedRequest);
   }
 
   @AfterEach
   public void afterEach() {
-    samlSessionMapper = dynamoDbEnhancedClient.table(TABLE_NAME,
-        TableSchema.fromBean(SAMLSession.class));
-    samlSessionMapper.deleteTable();
+    // Here we delete the -> {sessions_table_name} table with -> {sessions_g_idx} index
+
+    // We don't need to delete a table for each mapper because it is the same for each one -> {sessions_table_name}
+    // We use the oidcSessionMapper to be sure that even GlobalSecondaryIndex is deleted -> {sessions_g_idx}
+    oidcSessionMapper.deleteTable();
   }
 
   @Test
   void saveSAMLSession() {
 
     //given
-    SAMLSession session = new SAMLSession("id", RecordType.SAML, 0, 0, "test",
+    String requestId = "id";
+    String samlRequest = "test";
+    long creationTime = 0;
+    long ttl = 0;
+
+    SAMLSession samlSession = new SAMLSession(requestId, RecordType.SAML, creationTime, ttl,
+        samlRequest,
         AuthorizationRequestDTOExtended.builder().build());
 
-    Executable executable = () -> samlSessionConnectorImpl.saveSessionIfNotExists(session);
+    Executable executable = () -> samlSessionConnectorImpl.saveSessionIfNotExists(samlSession);
 
     //then
     assertDoesNotThrow(executable);
 
   }
 
+  @Test
+  void saveOIDCSession() {
+
+    //given
+    String requestId = "id";
+    long creationTime = 0;
+    long ttl = 0;
+    String authorizationCode = "code";
+
+    OIDCSession oidcSession = new OIDCSession(requestId, RecordType.OIDC, creationTime, ttl,
+        authorizationCode);
+
+    Executable executable = () -> oidcSessionConnectorImpl.saveSessionIfNotExists(oidcSession);
+
+    //then
+    assertDoesNotThrow(executable);
+
+  }
+
+  @Test
+  void saveAccessTokenSession() {
+
+    //given
+    String requestId = "id";
+    long creationTime = 0;
+    long ttl = 0;
+    String accessToken = "access-token";
+    String idToken = "id-token";
+
+    AccessTokenSession accessTokenSession = new AccessTokenSession(requestId,
+        RecordType.ACCESS_TOKEN, creationTime, ttl, accessToken, idToken);
+
+    Executable executable = () -> accessTokenSessionConnectorImpl.saveSessionIfNotExists(
+        accessTokenSession);
+
+    //then
+    assertDoesNotThrow(executable);
+
+  }
+
+  @Test
+  void saveDuplicatedSession() {
+
+    //given
+    String requestId = "id";
+    String samlRequest = "test";
+    long creationTime = 0;
+    long ttl = 0;
+
+    SAMLSession samlSession = new SAMLSession(requestId, RecordType.SAML, creationTime, ttl,
+        samlRequest,
+        AuthorizationRequestDTOExtended.builder().build());
+
+    Executable executable = () -> samlSessionConnectorImpl.saveSessionIfNotExists(samlSession);
+
+    //then
+    assertDoesNotThrow(executable);
+
+    // re-executing the save operation with the same session should throw a SessionException
+    assertThrows(SessionException.class, executable);
+
+  }
+
+  @Test
+  void saveUnrecognizedRecordTypeSession() {
+
+    //given
+    DummySession dummySession = new DummySession();
+
+    Executable executable = () -> dummySessionConnectorImpl.saveSessionIfNotExists(dummySession);
+
+    //then
+    assertThrows(SessionException.class, executable);
+
+  }
+
+  @Test
+  void findSAMLSession() throws SessionException {
+
+    //given
+    String requestId = "id";
+    String samlRequest = "test";
+    long creationTime = Instant.now().getEpochSecond();
+    long ttl = 0;
+
+    SAMLSession samlSession = new SAMLSession(requestId, RecordType.SAML, creationTime, ttl,
+        samlRequest,
+        AuthorizationRequestDTOExtended.builder().build());
+
+    Executable executable = () -> samlSessionConnectorImpl.saveSessionIfNotExists(samlSession);
+    assertDoesNotThrow(executable);
+
+    //then
+    assertFalse(samlSessionConnectorImpl.findSession(requestId, RecordType.SAML).isEmpty());
+
+  }
+
+  @Test
+  void findNotExistingSAMLSession() throws SessionException {
+
+    //given
+    String identifier = "id";
+    //then
+    assertTrue(samlSessionConnectorImpl.findSession(identifier, RecordType.SAML).isEmpty());
+
+  }
+
+  @Test
+  void findExpiredSAMLSession() throws SessionException {
+
+    //given
+    String requestId = "id";
+    String samlRequest = "test";
+    long creationTime = 0;
+    long ttl = 0;
+
+    SAMLSession samlSession = new SAMLSession(requestId, RecordType.SAML, creationTime, ttl,
+        samlRequest,
+        AuthorizationRequestDTOExtended.builder().build());
+
+    Executable executable = () -> samlSessionConnectorImpl.saveSessionIfNotExists(samlSession);
+    assertDoesNotThrow(executable);
+
+    //then
+    assertTrue(samlSessionConnectorImpl.findSession(requestId, RecordType.SAML).isEmpty());
+
+  }
+
+  @Test
+  void findOIDCSession() throws SessionException {
+    //given
+    String requestId = "id";
+    long creationTime = Instant.now().getEpochSecond();
+    long ttl = 0;
+    String authorizationCode = "code";
+
+    OIDCSession oidcSession = new OIDCSession(requestId, RecordType.OIDC, creationTime, ttl,
+        authorizationCode);
+
+    Executable executable = () -> oidcSessionConnectorImpl.saveSessionIfNotExists(oidcSession);
+    assertDoesNotThrow(executable);
+
+    //then
+    assertFalse(oidcSessionConnectorImpl.findSession(authorizationCode, RecordType.OIDC).isEmpty());
+  }
+
+  @Test
+  void findNotExistingOIDCSession() throws SessionException {
+    //given
+    String identifier = "id";
+    //then
+    assertTrue(oidcSessionConnectorImpl.findSession(identifier, RecordType.OIDC).isEmpty());
+  }
+
+  @Test
+  void findExpiredOIDCSession() throws SessionException {
+    //given
+    String requestId = "id";
+    long creationTime = 0;
+    long ttl = 0;
+    String authorizationCode = "code";
+
+    OIDCSession oidcSession = new OIDCSession(requestId, RecordType.OIDC, creationTime, ttl,
+        authorizationCode);
+
+    Executable executable = () -> oidcSessionConnectorImpl.saveSessionIfNotExists(oidcSession);
+    assertDoesNotThrow(executable);
+
+    //then
+    assertTrue(oidcSessionConnectorImpl.findSession(authorizationCode, RecordType.OIDC).isEmpty());
+  }
+
+  @Test
+  void findAccessTokenSession() throws SessionException {
+    //given
+    String requestId = "id";
+    long creationTime = Instant.now().getEpochSecond();
+    long ttl = 0;
+    String accessToken = "access-token";
+    String idToken = "id-token";
+
+    AccessTokenSession accessTokenSession = new AccessTokenSession(requestId,
+        RecordType.ACCESS_TOKEN, creationTime, ttl, accessToken, idToken);
+
+    Executable executable = () -> accessTokenSessionConnectorImpl.saveSessionIfNotExists(
+        accessTokenSession);
+
+    assertDoesNotThrow(executable);
+
+    //then
+    assertFalse(accessTokenSessionConnectorImpl.findSession(accessToken, RecordType.ACCESS_TOKEN)
+        .isEmpty());
+
+  }
+
+  @Test
+  void findNotExistingAccessTokenSession() throws SessionException {
+    //given
+    String identifier = "id";
+    //then
+    assertTrue(accessTokenSessionConnectorImpl.findSession(identifier, RecordType.ACCESS_TOKEN)
+        .isEmpty());
+
+  }
+
+  @Test
+  void findExpiredAccessTokenSession() throws SessionException {
+    //given
+    String requestId = "id";
+    long creationTime = 0;
+    long ttl = 0;
+    String accessToken = "access-token";
+    String idToken = "id-token";
+
+    AccessTokenSession accessTokenSession = new AccessTokenSession(requestId,
+        RecordType.ACCESS_TOKEN, creationTime, ttl, accessToken, idToken);
+
+    Executable executable = () -> accessTokenSessionConnectorImpl.saveSessionIfNotExists(
+        accessTokenSession);
+
+    assertDoesNotThrow(executable);
+
+    //then
+    assertTrue(accessTokenSessionConnectorImpl.findSession(accessToken, RecordType.ACCESS_TOKEN)
+        .isEmpty());
+
+  }
+
+  @Test
+  void updateSAMLSession() {
+    //given
+    String requestId = "id";
+    String samlRequest = "test";
+    long creationTime = Instant.now().getEpochSecond();
+    long ttl = 0;
+
+    SAMLSession samlSession = new SAMLSession(requestId, RecordType.SAML, creationTime, ttl,
+        samlRequest,
+        AuthorizationRequestDTOExtended.builder().build());
+
+    Executable executable = () -> samlSessionConnectorImpl.saveSessionIfNotExists(samlSession);
+
+    assertDoesNotThrow(executable);
+
+    //then
+    String samlResponse = "test";
+    executable = () -> samlSessionConnectorImpl.updateSAMLSession(requestId, samlResponse);
+    assertDoesNotThrow(executable);
+
+  }
+
+  @Test
+  void updateNotExistingValidSAMLSession() {
+    //given
+    String requestId = "id";
+    String samlResponse = "test";
+
+    //then
+    Executable executable = () -> samlSessionConnectorImpl.updateSAMLSession(requestId,
+        samlResponse);
+    assertThrows(SessionException.class, executable);
+
+  }
+
+  @Test
+  void updateSAMLSessionWithExistingSAMLResponse() {
+    //given
+    String requestId = "id";
+    String samlRequest = "test";
+    long creationTime = Instant.now().getEpochSecond();
+    long ttl = 0;
+
+    SAMLSession samlSession = new SAMLSession(requestId, RecordType.SAML, creationTime, ttl,
+        samlRequest,
+        AuthorizationRequestDTOExtended.builder().build());
+
+    Executable executable = () -> samlSessionConnectorImpl.saveSessionIfNotExists(samlSession);
+
+    assertDoesNotThrow(executable);
+
+    String samlResponse = "test";
+    executable = () -> samlSessionConnectorImpl.updateSAMLSession(requestId, samlResponse);
+    assertDoesNotThrow(executable);
+
+    //then
+    assertThrows(SessionException.class, executable);
+
+  }
 }

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/connector/model/DummySession.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/connector/model/DummySession.java
@@ -1,0 +1,7 @@
+package it.pagopa.oneid.connector.model;
+
+import it.pagopa.oneid.model.session.Session;
+
+public class DummySession extends Session {
+
+}

--- a/src/oneid/pom.xml
+++ b/src/oneid/pom.xml
@@ -43,6 +43,11 @@
             <name>Shibboleth Build Releases Repository</name>
             <url>https://build.shibboleth.net/nexus/content/repositories/releases/</url>
         </repository>
+        <repository>
+            <id>dynamodb-local-frankfurt</id>
+            <name>DynamoDB Local Release Repository</name>
+            <url>https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/release</url>
+        </repository>
     </repositories>
     <dependencyManagement>
         <dependencies>
@@ -168,6 +173,26 @@
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcpkix-jdk18on</artifactId>
                 <version>1.78.1</version>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/com.amazonaws/DynamoDBLocal -->
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>DynamoDBLocal</artifactId>
+                <version>2.5.2</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.github.ganadist.sqlite4java</groupId>
+                <artifactId>libsqlite4java-osx-aarch64</artifactId>
+                <version>1.0.392</version>
+                <scope>test</scope>
+                <type>dylib</type>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>2.23.1</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This **PR** adds setup for testing with a local `DynamoDB` _in-memory_ instance to improve Connector Layer test's effectiveness.

Tests to improve `SessionConnectorImpl` coverage are also added.

