### PR TITLE
Test: add ecs core connector tests

### DIFF
--- a/.github/workflows/deploy-oneid-core.yml
+++ b/.github/workflows/deploy-oneid-core.yml
@@ -30,10 +30,11 @@ jobs:
         run: |
           echo "github.ref ${{ github.ref }}"
           echo "event name ${{ github.event_name }}"
+          
 
           if [ ${{ github.ref == 'refs/heads/main' }} == true ] && [ ${{ github.event_name != 'workflow_dispatch' }} == true ]; then
             matrixStringifiedObject="{\"include\":[{\"environment\":\"uat\", \"env_short\": \"u\"},{\"environment\":\"prod\", \"env_short\": \"p\"}]}"
-          elif [ ${{ github.event.inputs.environment == 'uat' }}  ]; then
+          elif [ ${{ github.event.inputs.environment == 'uat' }} == true  ]; then
             matrixStringifiedObject="{\"include\":[{\"environment\":\"uat\", \"env_short\": \"u\"}]}"
           else
             matrixStringifiedObject="{\"include\":[{\"environment\":\"dev\", \"env_short\": \"d\"}]}"        

--- a/.github/workflows/deploy-oneid-core.yml
+++ b/.github/workflows/deploy-oneid-core.yml
@@ -40,6 +40,8 @@ jobs:
           fi
 
           echo "matrix=$matrixStringifiedObject" >> $GITHUB_OUTPUT
+          echo "matrixStringifiedObject $matrixStringifiedObject"
+          echo "matrix ${matrix}"
   
   deploy:
     name: "Deploy on ECS"

--- a/src/oneid/oneid-ecs-core/Dockerfile
+++ b/src/oneid/oneid-ecs-core/Dockerfile
@@ -23,7 +23,7 @@ RUN ["./mvnw", "verify", "clean", "--fail-never"]
 
 # This will use a workaround to load an env file, since is
 # not supported in docker build
-RUN export $(grep -v ^# ${ENVFILE}| xargs); ./mvnw -f pom.xml -B package -P oneid-ecs-core-aggregate
+RUN export $(grep -v ^# ${ENVFILE}| xargs); ./mvnw -f pom.xml -B package -P oneid-ecs-core-aggregate -Dmaven.test.skip=true
 
 ## Stage 2 : create the docker final image
 FROM registry.access.redhat.com/ubi8/openjdk-21-runtime:1.20-2

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/KMSConnector.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/KMSConnector.java
@@ -13,7 +13,7 @@ public interface KMSConnector {
     return result;
   }
 
-  SignResponse sign(byte[] headerBytes, byte[] payloadBytes);
+  SignResponse sign(String kmsKeyID, byte[] headerBytes, byte[] payloadBytes);
 
-  GetPublicKeyResponse getPublicKey();
+  GetPublicKeyResponse getPublicKey(String kmsKeyID);
 }

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/KMSConnectorImpl.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/KMSConnectorImpl.java
@@ -2,7 +2,6 @@ package it.pagopa.oneid.connector;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.GetPublicKeyRequest;
@@ -15,23 +14,15 @@ import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
 @ApplicationScoped
 public class KMSConnectorImpl implements KMSConnector {
 
-  @ConfigProperty(name = "kms_key_id")
-  private static String KMS_KEY_ID;
-
   @Inject
   KmsClient kmsClient;
 
-  @Inject
-  KMSConnectorImpl(@ConfigProperty(name = "kms_key_id") String kmsKeyID) {
-    KMS_KEY_ID = kmsKeyID;
-  }
-
   @Override
-  public SignResponse sign(byte[] headerBytes, byte[] payloadBytes) {
+  public SignResponse sign(String kmsKeyID, byte[] headerBytes, byte[] payloadBytes) {
     // Sign header and payload using KMS Sign operation
     byte[] contentBytes = KMSConnector.concatenateArrays(headerBytes, (byte) '.', payloadBytes);
     SignRequest signRequest = SignRequest.builder()
-        .keyId(KMS_KEY_ID)
+        .keyId(kmsKeyID)
         .messageType(MessageType.RAW)
         .message(SdkBytes.fromByteArray(contentBytes))
         .signingAlgorithm(SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_256)
@@ -40,10 +31,10 @@ public class KMSConnectorImpl implements KMSConnector {
   }
 
   @Override
-  public GetPublicKeyResponse getPublicKey() {
+  public GetPublicKeyResponse getPublicKey(String kmsKeyID) {
 
     GetPublicKeyRequest getPublicKeyRequest = GetPublicKeyRequest.builder()
-        .keyId(KMS_KEY_ID)
+        .keyId(kmsKeyID)
         .build();
     return kmsClient.getPublicKey(getPublicKeyRequest);
   }

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/OIDCServiceImpl.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/OIDCServiceImpl.java
@@ -46,30 +46,31 @@ import java.security.spec.X509EncodedKeySpec;
 import java.text.ParseException;
 import java.util.List;
 import java.util.Map;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import software.amazon.awssdk.services.kms.model.GetPublicKeyResponse;
 
 @ApplicationScoped
 public class OIDCServiceImpl implements OIDCService {
 
   @Inject
-  OIDCUtils oidcUtils;
+  @ConfigProperty(name = "kms_key_id")
+  String KMS_KEY_ID;
 
+  @Inject
+  OIDCUtils oidcUtils;
   @Inject
   KMSConnectorImpl kmsConnectorImpl;
-
   @Inject
   ClientConnectorImpl clientConnectorImpl;
-
   @Inject
   Map<String, Client> clientsMap;
-
   @Inject
   SAMLUtilsConstants samlConstants;
 
   @Override
   public JWKSSetDTO getJWSKPublicKey() {
     Log.debug("start");
-    GetPublicKeyResponse getPublicKeyResponse = kmsConnectorImpl.getPublicKey();
+    GetPublicKeyResponse getPublicKeyResponse = kmsConnectorImpl.getPublicKey(KMS_KEY_ID);
     RSAPublicKey rsaPublicKey;
     try {
       rsaPublicKey = (RSAPublicKey) KeyFactory.getInstance("RSA")

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/utils/OIDCUtils.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/utils/OIDCUtils.java
@@ -14,12 +14,17 @@ import jakarta.inject.Inject;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import software.amazon.awssdk.services.kms.model.SignResponse;
 
 @ApplicationScoped
 public class OIDCUtils {
 
   private static final Base64.Encoder base64UrlEncoder = Base64.getUrlEncoder().withoutPadding();
+
+  @Inject
+  @ConfigProperty(name = "kms_key_id")
+  String KMS_KEY_ID;
 
   @Inject
   KMSConnectorImpl kmsConnectorImpl;
@@ -58,7 +63,7 @@ public class OIDCUtils {
     byte[] encodedPayload = base64UrlEncoder.encodeToString(payloadBytes).getBytes();
 
     // Create a signature with base64 encoded header and payload
-    SignResponse signResponse = kmsConnectorImpl.sign(encodedHeader, encodedPayload);
+    SignResponse signResponse = kmsConnectorImpl.sign(KMS_KEY_ID, encodedHeader, encodedPayload);
     String base64Sign = base64UrlEncoder.encodeToString(signResponse.signature().asByteArray());
 
     // Concatenation of JWT parts to obtain the pattern header.payload.signature

--- a/src/oneid/oneid-ecs-core/src/main/resources/application.properties
+++ b/src/oneid/oneid-ecs-core/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 quarkus.dynamodb.devservices.enabled=false
-quarkus.kms.devservices.enabled=false
+quarkus.kms.devservices.enabled=true
 sessions_table_name=${SESSIONS_TABLE_NAME:Sessions}
 sessions_g_idx=${SESSIONS_G_IDX:gsi_code_idx}
 kms_key_id=${KMS_KEY_ID:12ec0889-8be5-4719-ab6f-91e1bf017fc4}

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/connector/KMSConnectorImplTest.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/connector/KMSConnectorImplTest.java
@@ -1,14 +1,17 @@
 package it.pagopa.oneid.connector;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.CreateKeyRequest;
 import software.amazon.awssdk.services.kms.model.CreateKeyResponse;
+import software.amazon.awssdk.services.kms.model.GetPublicKeyResponse;
 import software.amazon.awssdk.services.kms.model.KeySpec;
 import software.amazon.awssdk.services.kms.model.KeyUsageType;
 import software.amazon.awssdk.services.kms.model.SignResponse;
@@ -42,6 +45,41 @@ public class KMSConnectorImplTest {
         header.getBytes(StandardCharsets.UTF_8),
         payload.getBytes(StandardCharsets.UTF_8));
 
+    // then
     assertFalse(signResponse.toString().isEmpty());
+  }
+
+  @Test
+  void signWithNotExistingKeyID() {
+    // given
+    String header = "testHeader";
+    String payload = "testPayload";
+    String dummyKeyID = "dummy";
+
+    Executable executable = () -> kmsConnectorImpl.sign(dummyKeyID,
+        header.getBytes(StandardCharsets.UTF_8),
+        payload.getBytes(StandardCharsets.UTF_8));
+
+    // then
+    assertThrows(Exception.class, executable);
+  }
+
+  @Test
+  void getPublicKey() {
+    // given
+    GetPublicKeyResponse publicKeyResponse = kmsConnectorImpl.getPublicKey(kmsKeyID);
+
+    // then
+    assertFalse(publicKeyResponse.publicKey().toString().isEmpty());
+  }
+
+  @Test
+  void getNotExistingPublicKey() {
+    // given
+    String dummyKeyID = "dummy";
+    Executable executable = () -> kmsConnectorImpl.getPublicKey(dummyKeyID);
+
+    // then
+    assertThrows(Exception.class, executable);
   }
 }

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/connector/KMSConnectorImplTest.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/connector/KMSConnectorImplTest.java
@@ -1,0 +1,47 @@
+package it.pagopa.oneid.connector;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.kms.model.CreateKeyRequest;
+import software.amazon.awssdk.services.kms.model.CreateKeyResponse;
+import software.amazon.awssdk.services.kms.model.KeySpec;
+import software.amazon.awssdk.services.kms.model.KeyUsageType;
+import software.amazon.awssdk.services.kms.model.SignResponse;
+
+@QuarkusTest
+public class KMSConnectorImplTest {
+
+  private static String kmsKeyID;
+  @Inject
+  KMSConnectorImpl kmsConnectorImpl;
+  @Inject
+  KmsClient kmsClient;
+
+  @BeforeEach
+  void beforeEach() {
+    CreateKeyResponse result = kmsClient.createKey(CreateKeyRequest.
+        builder()
+        .keySpec(KeySpec.RSA_2048)
+        .keyUsage(KeyUsageType.SIGN_VERIFY)
+        .build());
+    kmsKeyID = result.keyMetadata().keyId();
+  }
+
+  @Test
+  void sign() {
+    // given
+    String header = "testHeader";
+    String payload = "testPayload";
+
+    SignResponse signResponse = kmsConnectorImpl.sign(kmsKeyID,
+        header.getBytes(StandardCharsets.UTF_8),
+        payload.getBytes(StandardCharsets.UTF_8));
+
+    assertFalse(signResponse.toString().isEmpty());
+  }
+}

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/connector/SessionConnectorImplTest.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/connector/SessionConnectorImplTest.java
@@ -16,7 +16,6 @@ import it.pagopa.oneid.model.session.enums.RecordType;
 import it.pagopa.oneid.web.dto.AuthorizationRequestDTOExtended;
 import jakarta.inject.Inject;
 import java.time.Instant;
-import lombok.SneakyThrows;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -62,11 +61,9 @@ class SessionConnectorImplTest {
   @ConfigProperty(name = "sessions_g_idx")
   String IDX_NAME;
 
-  @SneakyThrows
   @Inject
   public SessionConnectorImplTest() {
     System.setProperty("sqlite4java.library.path", "target/test/native-libs");
-
   }
 
   @BeforeAll

--- a/src/oneid/pom.xml
+++ b/src/oneid/pom.xml
@@ -249,7 +249,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire-plugin.version}</version>
                 <configuration>
-                    <skipTests>true</skipTests>
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager
                         </java.util.logging.manager>

--- a/src/oneid/pom.xml
+++ b/src/oneid/pom.xml
@@ -249,6 +249,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire-plugin.version}</version>
                 <configuration>
+                    <skipTests>true</skipTests>
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager
                         </java.util.logging.manager>


### PR DESCRIPTION
This **PR** adds general setup for `KMSConnector` tests using Quarkus Dev Services (LocalStack _under the hood_) to emulate KMS giving much more effectiveness to the test suite.

`KMSConnectorImpl` tests are also added.

It introduces a small refactoring for the injection of the `KMSKeyID` to improve method testability.