### PR TITLE
Test: add ecs core SessionServiceImpl tests

### DIFF
--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/SessionConnectorImpl.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/SessionConnectorImpl.java
@@ -36,12 +36,15 @@ import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedExce
 @Dependent
 public class SessionConnectorImpl<T extends Session> implements SessionConnector<T> {
 
-  private final DynamoDbTable<SAMLSession> samlSessionMapper;
-  private final DynamoDbTable<OIDCSession> oidcSessionMapper;
-  private final DynamoDbTable<AccessTokenSession> accessTokenSessionMapper;
-  private final DynamoDbIndex<OIDCSession> oidcSessionDynamoDbIndex;
-  private final DynamoDbIndex<AccessTokenSession> accessTokenSessionDynamoDbIndex;
+  private DynamoDbTable<SAMLSession> samlSessionMapper;
+  private DynamoDbTable<OIDCSession> oidcSessionMapper;
+  private DynamoDbTable<AccessTokenSession> accessTokenSessionMapper;
+  private DynamoDbIndex<OIDCSession> oidcSessionDynamoDbIndex;
+  private DynamoDbIndex<AccessTokenSession> accessTokenSessionDynamoDbIndex;
 
+  public SessionConnectorImpl() {
+    
+  }
 
   @Inject
   SessionConnectorImpl(DynamoDbEnhancedClient dynamoDbEnhancedClient,

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/MockSessionConnectorImpl.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/MockSessionConnectorImpl.java
@@ -1,0 +1,44 @@
+package it.pagopa.oneid.service;
+
+import it.pagopa.oneid.connector.SessionConnectorImpl;
+import it.pagopa.oneid.model.session.SAMLSession;
+import it.pagopa.oneid.model.session.Session;
+import it.pagopa.oneid.model.session.enums.RecordType;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+import java.util.Optional;
+import javax.annotation.Priority;
+
+@Alternative
+@Priority(1)
+@Dependent
+public class MockSessionConnectorImpl<T extends Session> extends SessionConnectorImpl<T> {
+
+  public MockSessionConnectorImpl() {
+    super();
+  }
+
+  @Override
+  public void saveSessionIfNotExists(T session) {
+    // do nothing
+  }
+
+  @Override
+  public Optional<T> findSession(String identifier, RecordType recordType) {
+    // todo: consider setting specific value as test constants
+    if (identifier.equals("withValue")) {
+      SAMLSession session = new SAMLSession();
+      return (Optional<T>) Optional.of(session);
+    } else if (identifier.equals("codeWithValue")) {
+      SAMLSession session = new SAMLSession("withValue", RecordType.SAML, 0, 0, null, null);
+      session.setSAMLResponse("test");
+      return (Optional<T>) Optional.of(session);
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public void updateSAMLSession(String samlRequestID, String SAMLResponse) {
+    // do nothing
+  }
+}

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/MyMockyTestProfile.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/MyMockyTestProfile.java
@@ -1,0 +1,16 @@
+package it.pagopa.oneid.service;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+import java.util.Set;
+
+/**
+ * Defines a 'test profile'. Tests run under a test profile will have different configuration
+ * options to other tests.
+ */
+public class MyMockyTestProfile implements QuarkusTestProfile {
+
+  @Override
+  public Set<Class<?>> getEnabledAlternatives() {
+    return Set.of(MockSessionConnectorImpl.class);
+  }
+}

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/SessionServiceImplTest.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/SessionServiceImplTest.java
@@ -1,0 +1,118 @@
+package it.pagopa.oneid.service;
+
+import static org.junit.jupiter.api.Assertions.fail;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import it.pagopa.oneid.connector.SessionConnectorImpl;
+import it.pagopa.oneid.exception.SessionException;
+import it.pagopa.oneid.model.session.SAMLSession;
+import it.pagopa.oneid.model.session.enums.RecordType;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+@QuarkusTest
+@TestProfile(MyMockyTestProfile.class)
+public class SessionServiceImplTest {
+
+  @Inject
+  SessionServiceImpl<SAMLSession> sessionServiceImpl;
+
+  @Inject
+  SessionConnectorImpl<SAMLSession> sessionConnectorImpl;
+
+  @Test
+  void saveSession() {
+    // given
+    SAMLSession session = Mockito.mock(SAMLSession.class);
+    try {
+      sessionServiceImpl.saveSession(session);
+    } catch (Exception e) {
+      fail("Unexpected exception thrown: " + e.getMessage());
+    }
+
+  }
+
+  @Test
+  void saveNullSession() {
+    try {
+      sessionServiceImpl.saveSession(null);
+      fail("Should have thrown SessionException");
+    } catch (SessionException ignored) {
+    }
+
+  }
+
+  @Test
+  void getSession() {
+    // given
+    String idWithValue = "withValue";
+    RecordType recordType = RecordType.SAML;
+
+    // then
+    try {
+      sessionServiceImpl.getSession(idWithValue, recordType);
+    } catch (Exception e) {
+      fail("Unexpected exception: " + e.getMessage());
+    }
+
+  }
+
+  @Test
+  void getSessionNotExistingItem() {
+    // given
+    String idWithNoValue = "withNoValue";
+    RecordType recordType = RecordType.SAML;
+
+    // then
+    try {
+      sessionServiceImpl.getSession(idWithNoValue, recordType);
+      fail("Should have thrown SessionException");
+    } catch (Exception ignored) {
+    }
+
+  }
+
+  @Test
+  void setSAMLResponse() {
+    // given
+    String samlRequestID = "requestID";
+    String response = "test";
+
+    // then
+    try {
+      sessionServiceImpl.setSAMLResponse(samlRequestID, response);
+    } catch (Exception e) {
+      fail("Unexpected exception: " + e.getMessage());
+    }
+
+  }
+
+  @Test
+  void getSAMLSessionByCode() {
+    // given
+    String codeWithValue = "codeWithValue";
+
+    // then
+    try {
+      sessionServiceImpl.getSAMLSessionByCode(codeWithValue);
+    } catch (Exception e) {
+      fail("Unexpected exception: " + e.getMessage());
+    }
+
+  }
+
+  @Test
+  void getSAMLResponseByCode() {
+    // given
+    String codeWithValue = "codeWithValue";
+
+    // then
+    try {
+      sessionServiceImpl.getSAMLResponseByCode(codeWithValue);
+    } catch (Exception e) {
+      fail("Unexpected exception: " + e.getMessage());
+    }
+
+  }
+}

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/utils/OIDCUtilsTest.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/utils/OIDCUtilsTest.java
@@ -1,0 +1,51 @@
+package it.pagopa.oneid.service.utils;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import io.quarkus.test.junit.QuarkusMock;
+import io.quarkus.test.junit.QuarkusTest;
+import it.pagopa.oneid.connector.KMSConnectorImpl;
+import it.pagopa.oneid.model.dto.AttributeDTO;
+import jakarta.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.Mockito;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.kms.model.SignResponse;
+
+@QuarkusTest
+public class OIDCUtilsTest {
+
+  @Inject
+  OIDCUtils oidcUtils;
+
+  @Inject
+  KMSConnectorImpl kmsConnectorImpl;
+
+
+  @Test
+  void createSignedJWT() {
+    // given
+    String requestId = "requestId";
+    String clientId = "clientId";
+    String nonce = "nonce";
+    List<AttributeDTO> attributeDTOList = new ArrayList<AttributeDTO>();
+    attributeDTOList.add(new AttributeDTO("testName", "testValue"));
+
+    kmsConnectorImpl = Mockito.mock(KMSConnectorImpl.class);
+    SignResponse mockedSignResponse = Mockito.mock(SignResponse.class);
+    Mockito.when(mockedSignResponse.signature())
+        .thenReturn(SdkBytes.fromByteArray("test".getBytes()));
+    Mockito.when(kmsConnectorImpl.sign(Mockito.any(), Mockito.any(), Mockito.any()))
+        .thenReturn(mockedSignResponse);
+    QuarkusMock.installMockForType(kmsConnectorImpl, KMSConnectorImpl.class);
+
+    Executable executable = () -> oidcUtils.createSignedJWT(requestId, clientId, attributeDTOList,
+        nonce);
+
+    // then
+    assertDoesNotThrow(executable);
+  }
+
+}


### PR DESCRIPTION
This **PR** adds `SessionServiceImpl` unit tests.

It adds some _Mocked_ beans to improve tests effectiveness and correctly separate behaviours between different application's layers.

Minor code refactoring in `SessionConnectorImpl` which includes the definition of parameterless constructor for enabling mocking.