### PR TITLE
Test: improve oneid-ecs-core Service Layer tests coverage

### DIFF
--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/MockClientProducer.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/MockClientProducer.java
@@ -1,0 +1,34 @@
+package it.pagopa.oneid.service;
+
+import it.pagopa.oneid.common.model.Client;
+import it.pagopa.oneid.common.model.enums.AuthLevel;
+import it.pagopa.oneid.common.utils.producers.ClientProducer;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.ws.rs.Produces;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Priority;
+
+@Alternative
+@Priority(1)
+@Dependent
+public class MockClientProducer extends ClientProducer {
+
+  @ApplicationScoped
+  @Produces
+  Map<String, Client> clientsMap() {
+    Map<String, Client> map = new HashMap<>();
+    ArrayList<Client> clients = new ArrayList<>();
+    clients.add(
+        new Client("test", "test", Set.of("foo.bar"), Set.of("test"), AuthLevel.L2, 0, 0, true, 0,
+            "test", "test", "test"));
+
+    clients.forEach(client -> map.put(client.getClientId(), client));
+
+    return map;
+  }
+}

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/MyMockyTestProfile.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/MyMockyTestProfile.java
@@ -11,6 +11,6 @@ public class MyMockyTestProfile implements QuarkusTestProfile {
 
   @Override
   public Set<Class<?>> getEnabledAlternatives() {
-    return Set.of(MockSessionConnectorImpl.class);
+    return Set.of(MockSessionConnectorImpl.class, MockClientProducer.class);
   }
 }

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/OIDCServiceImplTest.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/OIDCServiceImplTest.java
@@ -1,0 +1,204 @@
+package it.pagopa.oneid.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import com.nimbusds.oauth2.sdk.AuthorizationRequest;
+import com.nimbusds.oauth2.sdk.AuthorizationResponse;
+import com.nimbusds.oauth2.sdk.ResponseMode;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.State;
+import io.quarkus.test.junit.QuarkusMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import it.pagopa.oneid.common.connector.ClientConnectorImpl;
+import it.pagopa.oneid.common.model.Client;
+import it.pagopa.oneid.common.model.dto.SecretDTO;
+import it.pagopa.oneid.common.utils.SAMLUtilsConstants;
+import it.pagopa.oneid.exception.InvalidClientException;
+import it.pagopa.oneid.exception.OIDCSignJWTException;
+import it.pagopa.oneid.model.dto.AttributeDTO;
+import it.pagopa.oneid.model.dto.AuthorizationRequestDTO;
+import it.pagopa.oneid.model.session.enums.ResponseType;
+import it.pagopa.oneid.service.utils.OIDCUtils;
+import it.pagopa.oneid.web.dto.TokenDataDTO;
+import jakarta.inject.Inject;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+import net.minidev.json.JSONObject;
+import net.minidev.json.parser.JSONParser;
+import net.minidev.json.parser.ParseException;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+@QuarkusTest
+@TestProfile(MyMockyTestProfile.class)
+public class OIDCServiceImplTest {
+
+  @Inject
+  OIDCServiceImpl oidcServiceImpl;
+
+  @Inject
+  SAMLUtilsConstants samlConstants;
+
+  @Inject
+  OIDCUtils oidcUtils;
+
+  @Inject
+  ClientConnectorImpl clientConnectorImpl;
+
+  @Inject
+  Map<String, Client> clientsMap;
+
+  @Test
+  void buildOIDCProviderMetadata() {
+    assertDoesNotThrow(() -> oidcServiceImpl.buildOIDCProviderMetadata());
+  }
+
+  @Test
+  void buildAuthorizationRequest() {
+    // given
+    AuthorizationRequestDTO authorizationRequestDTO = new AuthorizationRequestDTO("test",
+        ResponseType.CODE, "test.com", "dummy", "foo", "bar");
+
+    AuthorizationRequest authorizationRequestResponse = oidcServiceImpl.buildAuthorizationRequest(
+        authorizationRequestDTO);
+
+    // then
+    assertEquals(authorizationRequestResponse.getClientID().getValue(),
+        authorizationRequestDTO.getClientId());
+  }
+
+  @Test
+  void buildAuthorizationRequest_RuntimeException() {
+    // given
+    AuthorizationRequestDTO authorizationRequestDTO = new AuthorizationRequestDTO("test",
+        ResponseType.CODE, "test..!!@@<>com", "dummy", "foo", "bar");
+    // then
+    assertThrows(RuntimeException.class, () -> oidcServiceImpl.buildAuthorizationRequest(
+        authorizationRequestDTO));
+  }
+
+  @Test
+  void getAuthorizationResponse() throws URISyntaxException {
+    // given
+    AuthorizationRequest authorizationRequest = new AuthorizationRequest(new URI("foo.bar"),
+        com.nimbusds.oauth2.sdk.ResponseType.CODE, ResponseMode.JWT, new ClientID("test"),
+        new URI("foo.bar"), new Scope("dummy_scope"), new State("dummy_state"));
+
+    // then
+    AuthorizationResponse authorizationResponse = oidcServiceImpl.getAuthorizationResponse(
+        authorizationRequest);
+    assertEquals(authorizationResponse.getState(), authorizationRequest.getState());
+  }
+
+  @Test
+  void getOIDCTokens() throws ParseException {
+    // given
+    String requestID = "dummyId";
+    String clientID = "foobar";
+    String nonce = "dummyNonce";
+    ArrayList<AttributeDTO> attributeDTOList = new ArrayList<>();
+
+    oidcUtils = Mockito.mock(OIDCUtils.class);
+    String validJWT = "\n"
+        + "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE3MjQ4NTMxODcsImV4cCI6MTc1NjM4OTE4NywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsImZpc2NhbE51bWJlciI6InRlc3QifQ.LMeTd56BOmN-uEvSnXhIzmUjUQ7OQNATOUp2OYhsEOc";
+    Mockito.when(
+            oidcUtils.createSignedJWT(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+        .thenReturn(validJWT);
+    QuarkusMock.installMockForType(oidcUtils, OIDCUtils.class);
+
+    // then
+    TokenDataDTO tokenDataDTO = oidcServiceImpl.getOIDCTokens(requestID, clientID, attributeDTOList,
+        nonce);
+
+    Base64.Decoder decoder = Base64.getUrlDecoder();
+    String[] chunks = tokenDataDTO.getIdToken().split("\\.");
+    String payload = new String(decoder.decode(chunks[1]));
+
+    Object obj = new JSONParser().parse(payload);
+    JSONObject jo = (JSONObject) obj;
+
+    String fiscalNumber = (String) jo.get("fiscalNumber");
+
+    assertEquals(fiscalNumber, "test");
+  }
+
+  @Test
+  void getOIDCTokens_OIDCSignJWTException() {
+    // given
+    String requestID = "dummyId";
+    String clientID = "foobar";
+    String nonce = "dummyNonce";
+    ArrayList<AttributeDTO> attributeDTOList = new ArrayList<>();
+
+    oidcUtils = Mockito.mock(OIDCUtils.class);
+    String invalidJWT = "dummy";
+    Mockito.when(
+            oidcUtils.createSignedJWT(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+        .thenReturn(invalidJWT);
+    QuarkusMock.installMockForType(oidcUtils, OIDCUtils.class);
+
+    // then
+    assertThrows(OIDCSignJWTException.class, () ->
+        oidcServiceImpl.getOIDCTokens(requestID, clientID, attributeDTOList,
+            nonce));
+  }
+
+  @Test
+  void authorizeClient() {
+    // given
+    String clientID = "test";
+    String clientSecret = "ZHVtbXk="; // base 64 encoded of 'dummy'
+    String salt = "c2FsdGZvb2Jhcg=="; //base64 encoded of 'saltfoobar'
+    String hashedSecret = "qE1dd7kBTrtsKyU5CErJkj6g8Nhd25zlz97STo27iDg"; // argon2 of salt = 'saltfoobar' and secret = 'dummy'
+    clientConnectorImpl = Mockito.mock(ClientConnectorImpl.class);
+    SecretDTO secretDTO = new SecretDTO(hashedSecret, salt);
+
+    Mockito.when(clientConnectorImpl.getClientSecret(Mockito.any()))
+        .thenReturn(Optional.of(secretDTO));
+
+    QuarkusMock.installMockForType(clientConnectorImpl, ClientConnectorImpl.class);
+
+    // then
+    assertDoesNotThrow(
+        () -> oidcServiceImpl.authorizeClient(clientID, clientSecret));
+
+  }
+
+  @Test
+  void authorizeClient_nullClientID() {
+    // given
+    String clientID = "nullClient";
+    String clientSecret = "nullClientSecret";
+
+    // then
+    assertThrows(InvalidClientException.class,
+        () -> oidcServiceImpl.authorizeClient(clientID, clientSecret));
+
+  }
+
+  @Test
+  void authorizeClient_nullClientSecret() {
+    // given
+    String clientID = "test";
+    String clientSecret = "DummyClientSecret";
+
+    clientConnectorImpl = Mockito.mock(ClientConnectorImpl.class);
+
+    Mockito.when(clientConnectorImpl.getClientSecret(Mockito.any()))
+        .thenReturn(Optional.empty());
+
+    QuarkusMock.installMockForType(clientConnectorImpl, ClientConnectorImpl.class);
+    // then
+    assertThrows(InvalidClientException.class,
+        () -> oidcServiceImpl.authorizeClient(clientID, clientSecret));
+
+  }
+
+}

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/SAMLServiceImplTest.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/SAMLServiceImplTest.java
@@ -1,0 +1,441 @@
+package it.pagopa.oneid.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import io.quarkus.test.junit.QuarkusMock;
+import io.quarkus.test.junit.QuarkusTest;
+import it.pagopa.oneid.common.model.exception.OneIdentityException;
+import it.pagopa.oneid.common.model.exception.SAMLUtilsException;
+import it.pagopa.oneid.common.model.exception.enums.ErrorCode;
+import it.pagopa.oneid.common.utils.SAMLUtilsConstants;
+import it.pagopa.oneid.exception.SAMLResponseStatusException;
+import it.pagopa.oneid.exception.SAMLValidationException;
+import it.pagopa.oneid.model.dto.AttributeDTO;
+import it.pagopa.oneid.service.utils.MetadataResolverExtended;
+import it.pagopa.oneid.service.utils.SAMLUtilsExtendedCore;
+import jakarta.inject.Inject;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusCode;
+import org.opensaml.saml.saml2.core.StatusMessage;
+import org.opensaml.saml.saml2.core.Subject;
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import org.opensaml.saml.saml2.core.SubjectConfirmationData;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+
+@QuarkusTest
+public class SAMLServiceImplTest {
+
+  @Inject
+  SAMLServiceImpl samlServiceImpl;
+
+  @Inject
+  SAMLUtilsExtendedCore samlUtils;
+
+  @Inject
+  SAMLUtilsConstants samlUtilsConstants;
+
+  @Inject
+  MetadataResolverExtended metadataResolverExtended;
+
+  @Test
+  void checkSAMLStatus_StatusCodeSuccess() throws OneIdentityException {
+    // given
+    Response response = Mockito.mock(Response.class);
+    Status status = Mockito.mock(Status.class);
+    StatusCode statusCode = Mockito.mock(StatusCode.class);
+
+    Mockito.when(statusCode.getValue()).thenReturn(StatusCode.SUCCESS);
+    Mockito.when(status.getStatusCode()).thenReturn(statusCode);
+    Mockito.when(response.getStatus()).thenReturn(status);
+    // then
+    assertDoesNotThrow(() -> samlServiceImpl.checkSAMLStatus(response));
+  }
+
+  @Test
+  void checkSAMLStatus_StatusCodeNull() {
+    // given
+    Response response = Mockito.mock(Response.class);
+    Status status = Mockito.mock(Status.class);
+
+    Mockito.when(status.getStatusCode()).thenReturn(null);
+    Mockito.when(response.getStatus()).thenReturn(status);
+    // then
+    assertThrows(OneIdentityException.class, () -> samlServiceImpl.checkSAMLStatus(response));
+  }
+
+  @Test
+  void checkSAMLStatus_StatusCodeNotSuccess() {
+    // given
+    Response response = Mockito.mock(Response.class);
+    Status status = Mockito.mock(Status.class);
+    StatusCode statusCode = Mockito.mock(StatusCode.class);
+    StatusMessage statusMessage = Mockito.mock(StatusMessage.class);
+
+    Mockito.when(statusMessage.getValue()).thenReturn(String.valueOf(ErrorCode.ERRORCODE_NR20));
+    Mockito.when(statusCode.getValue()).thenReturn(StatusCode.REQUESTER);
+    Mockito.when(status.getStatusCode()).thenReturn(statusCode);
+    Mockito.when(status.getStatusMessage()).thenReturn(statusMessage);
+    Mockito.when(response.getStatus()).thenReturn(status);
+    // then
+    assertThrows(SAMLResponseStatusException.class,
+        () -> samlServiceImpl.checkSAMLStatus(response));
+  }
+
+  @Test
+  void checkSAMLStatus_StatusCodeNotSuccess_emptyStatusMessage() {
+    // given
+    Response response = Mockito.mock(Response.class);
+    Status status = Mockito.mock(Status.class);
+    StatusCode statusCode = Mockito.mock(StatusCode.class);
+    StatusMessage statusMessage = Mockito.mock(StatusMessage.class);
+
+    Mockito.when(statusMessage.getValue()).thenReturn("");
+    Mockito.when(statusCode.getValue()).thenReturn(StatusCode.REQUESTER);
+    Mockito.when(status.getStatusCode()).thenReturn(statusCode);
+    Mockito.when(status.getStatusMessage()).thenReturn(statusMessage);
+    Mockito.when(response.getStatus()).thenReturn(status);
+    // then
+    assertThrows(OneIdentityException.class,
+        () -> samlServiceImpl.checkSAMLStatus(response));
+  }
+
+  // TODO implement
+    /* @Test
+  void buildAuthnRequest() throws SAMLUtilsException {
+    // given
+    String idpID = "foobar";
+    int assertionConsumerServiceIndex = 0;
+    int attributeConsumingServiceIndex = 0;
+    String authLevel = "dummy";
+
+    samlUtils = Mockito.mock(SAMLUtilsExtendedCore.class);
+    Mockito.when(samlUtils.generateSecureRandomId()).thenReturn("id");
+    AuthnRequest authnRequest = Mockito.mock(AuthnRequest.class);
+    Issuer issuer = Mockito.mock(Issuer.class);
+    NameIDPolicy nameIDPolicy = Mockito.mock(NameIDPolicy.class);
+    RequestedAuthnContext requestedAuthnContext = Mockito.mock(RequestedAuthnContext.class);
+    Signature signature = Mockito.mock(Signature.class);
+
+    Mockito.when(samlUtils.buildSAMLObject(Mockito.any())).thenReturn(authnRequest);
+    Mockito.when(samlUtils.buildIssuer()).thenReturn(issuer);
+    Mockito.when(samlUtils.buildNameIdPolicy()).thenReturn(nameIDPolicy);
+    Mockito.when(samlUtils.buildRequestedAuthnContext(Mockito.any()))
+        .thenReturn(requestedAuthnContext);
+    Mockito.when(samlUtils.buildDestination(Mockito.any())).thenReturn(Optional.of("dummy"));
+    Mockito.when(samlUtils.buildSignature(Mockito.any())).thenReturn(signature);
+    QuarkusMock.installMockForType(samlUtils, SAMLUtilsExtendedCore.class);
+
+   EntityDescriptor entityDescriptor = Mockito.mock(EntityDescriptor.class);
+    entityDescriptor.getIDPSSODescriptor()
+
+    Mockito.when(metadataResolverExtended.getEntityDescriptor(Mockito.any())).thenReturn("dummy");
+
+    // then
+    assertDoesNotThrow(() -> samlServiceImpl.buildAuthnRequest(idpID, assertionConsumerServiceIndex,
+        attributeConsumingServiceIndex, authLevel));
+  }*/
+
+  @Test
+  void validateSAMLResponse() throws SAMLUtilsException {
+    // given
+    String entityID = "dummy";
+    Response response = Mockito.mock(Response.class);
+    Assertion assertion = Mockito.mock(Assertion.class);
+    Mockito.when(response.getAssertions()).thenReturn(List.of(assertion));
+
+    Subject subject = Mockito.mock(Subject.class);
+    SubjectConfirmation subjectConfirmation = Mockito.mock(SubjectConfirmation.class);
+    SubjectConfirmationData subjectConfirmationData = Mockito.mock(SubjectConfirmationData.class);
+
+    Mockito.when(subjectConfirmationData.getRecipient()).thenReturn(SAMLUtilsConstants.ACS_URL);
+    Mockito.when(
+        subjectConfirmationData.getNotOnOrAfter()).thenReturn(Instant.now().plusSeconds(60));
+
+    Mockito.when(subjectConfirmation.getSubjectConfirmationData())
+        .thenReturn(subjectConfirmationData);
+    Mockito.when(subject.getSubjectConfirmations()).thenReturn(List.of(subjectConfirmation));
+    Mockito.when(assertion.getSubject()).thenReturn(subject);
+
+    samlUtils = Mockito.mock(SAMLUtilsExtendedCore.class);
+    Mockito.doNothing().when(samlUtils).validateSignature(Mockito.any(), Mockito.any());
+    QuarkusMock.installMockForType(samlUtils, SAMLUtilsExtendedCore.class);
+
+    // then
+    assertDoesNotThrow(() -> samlServiceImpl.validateSAMLResponse(response, entityID));
+  }
+
+  @Test
+  void validateSAMLResponse_invalidSignature() throws SAMLUtilsException {
+    // given
+    String entityID = "dummy";
+    Response response = Mockito.mock(Response.class);
+    Assertion assertion = Mockito.mock(Assertion.class);
+    Mockito.when(response.getAssertions()).thenReturn(List.of(assertion));
+
+    Subject subject = Mockito.mock(Subject.class);
+    SubjectConfirmation subjectConfirmation = Mockito.mock(SubjectConfirmation.class);
+    SubjectConfirmationData subjectConfirmationData = Mockito.mock(SubjectConfirmationData.class);
+
+    Mockito.when(subjectConfirmationData.getRecipient()).thenReturn(SAMLUtilsConstants.ACS_URL);
+    Mockito.when(
+        subjectConfirmationData.getNotOnOrAfter()).thenReturn(Instant.now().plusSeconds(60));
+
+    Mockito.when(subjectConfirmation.getSubjectConfirmationData())
+        .thenReturn(subjectConfirmationData);
+    Mockito.when(subject.getSubjectConfirmations()).thenReturn(List.of(subjectConfirmation));
+    Mockito.when(assertion.getSubject()).thenReturn(subject);
+
+    samlUtils = Mockito.mock(SAMLUtilsExtendedCore.class);
+    Mockito.doThrow(SAMLUtilsException.class)
+        .when(samlUtils).validateSignature(Mockito.any(), Mockito.any());
+    QuarkusMock.installMockForType(samlUtils, SAMLUtilsExtendedCore.class);
+
+    // then
+    assertThrows(OneIdentityException.class,
+        () -> samlServiceImpl.validateSAMLResponse(response, entityID));
+  }
+
+  @Test
+  void validateSAMLResponse_noAssertion() {
+    // given
+    String entityID = "dummy";
+    Response response = Mockito.mock(Response.class);
+    List<Assertion> assertions = new ArrayList<>();
+    Mockito.when(response.getAssertions()).thenReturn(assertions);
+
+    // then
+    assertThrows(SAMLValidationException.class,
+        () -> samlServiceImpl.validateSAMLResponse(response, entityID));
+  }
+
+  @Test
+  void validateSAMLResponse_nullSubjectConfirmationData() throws SAMLUtilsException {
+    // given
+    String entityID = "dummy";
+    Response response = Mockito.mock(Response.class);
+    Assertion assertion = Mockito.mock(Assertion.class);
+    Mockito.when(response.getAssertions()).thenReturn(List.of(assertion));
+
+    Subject subject = Mockito.mock(Subject.class);
+    SubjectConfirmation subjectConfirmation = Mockito.mock(SubjectConfirmation.class);
+
+    Mockito.when(subjectConfirmation.getSubjectConfirmationData())
+        .thenReturn(null);
+    Mockito.when(subject.getSubjectConfirmations()).thenReturn(List.of(subjectConfirmation));
+    Mockito.when(assertion.getSubject()).thenReturn(subject);
+
+    samlUtils = Mockito.mock(SAMLUtilsExtendedCore.class);
+    Mockito.doNothing().when(samlUtils).validateSignature(Mockito.any(), Mockito.any());
+    QuarkusMock.installMockForType(samlUtils, SAMLUtilsExtendedCore.class);
+
+    // then
+    assertThrows(SAMLValidationException.class,
+        () -> samlServiceImpl.validateSAMLResponse(response, entityID));
+  }
+
+  @Test
+  void validateSAMLResponse_differentRecipient() throws SAMLUtilsException {
+    // given
+    String entityID = "dummy";
+    Response response = Mockito.mock(Response.class);
+    Assertion assertion = Mockito.mock(Assertion.class);
+    Mockito.when(response.getAssertions()).thenReturn(List.of(assertion));
+
+    Subject subject = Mockito.mock(Subject.class);
+    SubjectConfirmation subjectConfirmation = Mockito.mock(SubjectConfirmation.class);
+    SubjectConfirmationData subjectConfirmationData = Mockito.mock(SubjectConfirmationData.class);
+
+    Mockito.when(subjectConfirmationData.getRecipient()).thenReturn("dummy");
+
+    Mockito.when(subjectConfirmation.getSubjectConfirmationData())
+        .thenReturn(subjectConfirmationData);
+    Mockito.when(subject.getSubjectConfirmations()).thenReturn(List.of(subjectConfirmation));
+    Mockito.when(assertion.getSubject()).thenReturn(subject);
+
+    samlUtils = Mockito.mock(SAMLUtilsExtendedCore.class);
+    Mockito.doNothing().when(samlUtils).validateSignature(Mockito.any(), Mockito.any());
+    QuarkusMock.installMockForType(samlUtils, SAMLUtilsExtendedCore.class);
+
+    // then
+    assertThrows(SAMLValidationException.class,
+        () -> samlServiceImpl.validateSAMLResponse(response, entityID));
+  }
+
+  @Test
+  void validateSAMLResponse_nullRecipient() throws SAMLUtilsException {
+    // given
+    String entityID = "dummy";
+    Response response = Mockito.mock(Response.class);
+    Assertion assertion = Mockito.mock(Assertion.class);
+    Mockito.when(response.getAssertions()).thenReturn(List.of(assertion));
+
+    Subject subject = Mockito.mock(Subject.class);
+    SubjectConfirmation subjectConfirmation = Mockito.mock(SubjectConfirmation.class);
+    SubjectConfirmationData subjectConfirmationData = Mockito.mock(SubjectConfirmationData.class);
+
+    Mockito.when(subjectConfirmationData.getRecipient()).thenReturn(null);
+
+    Mockito.when(subjectConfirmation.getSubjectConfirmationData())
+        .thenReturn(subjectConfirmationData);
+    Mockito.when(subject.getSubjectConfirmations()).thenReturn(List.of(subjectConfirmation));
+    Mockito.when(assertion.getSubject()).thenReturn(subject);
+
+    samlUtils = Mockito.mock(SAMLUtilsExtendedCore.class);
+    Mockito.doNothing().when(samlUtils).validateSignature(Mockito.any(), Mockito.any());
+    QuarkusMock.installMockForType(samlUtils, SAMLUtilsExtendedCore.class);
+
+    // then
+    assertThrows(SAMLValidationException.class,
+        () -> samlServiceImpl.validateSAMLResponse(response, entityID));
+  }
+
+  @Test
+  void validateSAMLResponse_nullGetNotOnOrAfter() throws SAMLUtilsException {
+    // given
+    String entityID = "dummy";
+    Response response = Mockito.mock(Response.class);
+    Assertion assertion = Mockito.mock(Assertion.class);
+    Mockito.when(response.getAssertions()).thenReturn(List.of(assertion));
+
+    Subject subject = Mockito.mock(Subject.class);
+    SubjectConfirmation subjectConfirmation = Mockito.mock(SubjectConfirmation.class);
+    SubjectConfirmationData subjectConfirmationData = Mockito.mock(SubjectConfirmationData.class);
+
+    Mockito.when(subjectConfirmationData.getRecipient()).thenReturn(SAMLUtilsConstants.ACS_URL);
+    Mockito.when(
+        subjectConfirmationData.getNotOnOrAfter()).thenReturn(null);
+
+    Mockito.when(subjectConfirmation.getSubjectConfirmationData())
+        .thenReturn(subjectConfirmationData);
+    Mockito.when(subject.getSubjectConfirmations()).thenReturn(List.of(subjectConfirmation));
+    Mockito.when(assertion.getSubject()).thenReturn(subject);
+
+    samlUtils = Mockito.mock(SAMLUtilsExtendedCore.class);
+    Mockito.doNothing().when(samlUtils).validateSignature(Mockito.any(), Mockito.any());
+    QuarkusMock.installMockForType(samlUtils, SAMLUtilsExtendedCore.class);
+
+    // then
+    assertThrows(SAMLValidationException.class,
+        () -> samlServiceImpl.validateSAMLResponse(response, entityID));
+  }
+
+  @Test
+  void validateSAMLResponse_notValidGetNotOnOrAfter() throws SAMLUtilsException {
+    // given
+    String entityID = "dummy";
+    Response response = Mockito.mock(Response.class);
+    Assertion assertion = Mockito.mock(Assertion.class);
+    Mockito.when(response.getAssertions()).thenReturn(List.of(assertion));
+
+    Subject subject = Mockito.mock(Subject.class);
+    SubjectConfirmation subjectConfirmation = Mockito.mock(SubjectConfirmation.class);
+    SubjectConfirmationData subjectConfirmationData = Mockito.mock(SubjectConfirmationData.class);
+
+    Mockito.when(subjectConfirmationData.getRecipient()).thenReturn(SAMLUtilsConstants.ACS_URL);
+    Mockito.when(
+        subjectConfirmationData.getNotOnOrAfter()).thenReturn(Instant.now().minusSeconds(60));
+
+    Mockito.when(subjectConfirmation.getSubjectConfirmationData())
+        .thenReturn(subjectConfirmationData);
+    Mockito.when(subject.getSubjectConfirmations()).thenReturn(List.of(subjectConfirmation));
+    Mockito.when(assertion.getSubject()).thenReturn(subject);
+
+    samlUtils = Mockito.mock(SAMLUtilsExtendedCore.class);
+    Mockito.doNothing().when(samlUtils).validateSignature(Mockito.any(), Mockito.any());
+    QuarkusMock.installMockForType(samlUtils, SAMLUtilsExtendedCore.class);
+
+    // then
+    assertThrows(SAMLValidationException.class,
+        () -> samlServiceImpl.validateSAMLResponse(response, entityID));
+  }
+
+  @Test
+  void getSAMLResponseFromString() throws OneIdentityException {
+    // given
+    samlUtils = Mockito.mock(SAMLUtilsExtendedCore.class);
+    Response response = Mockito.mock(Response.class);
+    Mockito.when(samlUtils.getSAMLResponseFromString(Mockito.any())).thenReturn(response);
+
+    QuarkusMock.installMockForType(samlUtils, SAMLUtilsExtendedCore.class);
+
+    // then
+
+    assertDoesNotThrow(() -> samlServiceImpl.getSAMLResponseFromString("dummy"));
+  }
+
+  @Test
+  void getAttributesFromSAMLAssertion() {
+    // given
+    samlUtils = Mockito.mock(SAMLUtilsExtendedCore.class);
+    AttributeDTO attributeDTO = Mockito.mock(AttributeDTO.class);
+    Assertion assertion = Mockito.mock(Assertion.class);
+    Mockito.when(samlUtils.getAttributeDTOListFromAssertion(Mockito.any()))
+        .thenReturn(Optional.of(List.of(attributeDTO)));
+
+    QuarkusMock.installMockForType(samlUtils, SAMLUtilsExtendedCore.class);
+
+    // then
+
+    assertDoesNotThrow(() -> samlServiceImpl.getAttributesFromSAMLAssertion(assertion));
+  }
+
+  @Test
+  void getAttributesFromSAMLAssertion_emptyAttributes() {
+    // given
+    samlUtils = Mockito.mock(SAMLUtilsExtendedCore.class);
+    Assertion assertion = Mockito.mock(Assertion.class);
+    Mockito.when(samlUtils.getAttributeDTOListFromAssertion(Mockito.any()))
+        .thenReturn(Optional.empty());
+
+    QuarkusMock.installMockForType(samlUtils, SAMLUtilsExtendedCore.class);
+
+    // then
+
+    assertThrows(OneIdentityException.class,
+        () -> samlServiceImpl.getAttributesFromSAMLAssertion(assertion));
+  }
+
+  @Test
+  void getEntityDescriptorFromEntityID() throws SAMLUtilsException {
+    // given
+    samlUtils = Mockito.mock(SAMLUtilsExtendedCore.class);
+    EntityDescriptor entityDescriptor = Mockito.mock(EntityDescriptor.class);
+    Mockito.when(samlUtils.getEntityDescriptor(Mockito.any()))
+        .thenReturn(Optional.of(entityDescriptor));
+
+    QuarkusMock.installMockForType(samlUtils, SAMLUtilsExtendedCore.class);
+
+    // then
+
+    assertDoesNotThrow(() -> samlServiceImpl.getEntityDescriptorFromEntityID("dummy"));
+
+    // then
+  }
+
+  @Test
+  void getEntityDescriptorFromEntityID_withException() throws SAMLUtilsException {
+    // given
+    samlUtils = Mockito.mock(SAMLUtilsExtendedCore.class);
+    Mockito.when(samlUtils.getEntityDescriptor(Mockito.any()))
+        .thenThrow(SAMLUtilsException.class);
+
+    QuarkusMock.installMockForType(samlUtils, SAMLUtilsExtendedCore.class);
+
+    // then
+
+    assertThrows(OneIdentityException.class,
+        () -> samlServiceImpl.getEntityDescriptorFromEntityID("dummy"));
+
+    // then
+  }
+
+
+}


### PR DESCRIPTION
This **PR** adds unit tests to `oneid-ecs-core` Service Layer