### PR TITLE
feat: edit pointer logic to align IS timestamp

### DIFF
--- a/src/oneid/oneid-common/connector/src/main/java/it/pagopa/oneid/common/connector/IDPConnector.java
+++ b/src/oneid/oneid-common/connector/src/main/java/it/pagopa/oneid/common/connector/IDPConnector.java
@@ -11,6 +11,6 @@ public interface IDPConnector {
 
   Optional<IDP> getIDPByEntityIDAndTimestamp(String entityID, String timestamp);
 
-  void saveIDPs(ArrayList<IDP> idpList, LatestTAG latestTag);
+  void saveIDPs(ArrayList<IDP> idpList, LatestTAG latestTag, String timestamp);
 
 }

--- a/src/oneid/oneid-common/connector/src/main/java/it/pagopa/oneid/common/connector/IDPConnectorImpl.java
+++ b/src/oneid/oneid-common/connector/src/main/java/it/pagopa/oneid/common/connector/IDPConnectorImpl.java
@@ -62,7 +62,7 @@ public class IDPConnectorImpl implements IDPConnector {
   }
 
   @Override
-  public void saveIDPs(ArrayList<IDP> idpList, LatestTAG latestTAG) {
+  public void saveIDPs(ArrayList<IDP> idpList, LatestTAG latestTAG, String timestamp) {
     Log.debug("start");
 
     Optional<ArrayList<IDP>> idpLatestList = findIDPsByTimestamp(String.valueOf(latestTAG));
@@ -71,7 +71,7 @@ public class IDPConnectorImpl implements IDPConnector {
     idpLatestList.ifPresent(idps -> {
       idps.forEach(idp -> {
         idpMapper.deleteItem(idp);
-        idp.setPointer(String.valueOf(idp.getTimestamp()));
+        idp.setPointer(timestamp);
         idpMapper.putItem(idp);
       });
 

--- a/src/oneid/oneid-common/connector/src/test/java/it/pagopa/oneid/common/connector/IDPConnectorImplTest.java
+++ b/src/oneid/oneid-common/connector/src/test/java/it/pagopa/oneid/common/connector/IDPConnectorImplTest.java
@@ -122,13 +122,13 @@ class IDPConnectorImplTest {
     Set<String> certificates = Collections.singleton("test");
     String friendlyName = "test";
 
-    IDP idp = new IDP(entityId, pointer, timestamp, isActive, idpStatus, idpSSOEndpoint,
+    IDP idp = new IDP(entityId, pointer, isActive, idpStatus, idpSSOEndpoint,
         certificates, friendlyName);
 
     ArrayList<IDP> idps = new ArrayList<>(Collections.singleton(idp));
 
     //then
-    idpConnectorImpl.saveIDPs(idps, LatestTAG.LATEST_SPID);
+    idpConnectorImpl.saveIDPs(idps, LatestTAG.LATEST_SPID, String.valueOf(timestamp));
 
     Optional<ArrayList<IDP>> idpList = idpConnectorImpl.findIDPsByTimestamp(
         String.valueOf(LatestTAG.LATEST_SPID));
@@ -139,7 +139,7 @@ class IDPConnectorImplTest {
 
   @Test
   void getIDPByEntityIDAndTimestamp_Empty() {
-    
+
     Optional<ArrayList<IDP>> idpList = idpConnectorImpl.findIDPsByTimestamp(
         String.valueOf(LatestTAG.LATEST_SPID));
 
@@ -159,13 +159,13 @@ class IDPConnectorImplTest {
     Set<String> certificates = Collections.singleton("test");
     String friendlyName = "test";
 
-    IDP idp = new IDP(entityId, pointer, timestamp, isActive, idpStatus, idpSSOEndpoint,
+    IDP idp = new IDP(entityId, pointer, isActive, idpStatus, idpSSOEndpoint,
         certificates, friendlyName);
 
     ArrayList<IDP> idps = new ArrayList<>(Collections.singleton(idp));
 
     //then
-    idpConnectorImpl.saveIDPs(idps, LatestTAG.LATEST_SPID);
+    idpConnectorImpl.saveIDPs(idps, LatestTAG.LATEST_SPID, String.valueOf(timestamp));
 
     IDP savedIdp = idpConnectorImpl.getIDPByEntityIDAndTimestamp(entityId,
         String.valueOf(LatestTAG.LATEST_SPID)).get();
@@ -187,12 +187,12 @@ class IDPConnectorImplTest {
     Set<String> certificates = Collections.singleton("test");
     String friendlyName = "test";
 
-    IDP idp = new IDP(entityId, pointer, timestamp, isActive, idpStatus, idpSSOEndpoint,
+    IDP idp = new IDP(entityId, pointer, isActive, idpStatus, idpSSOEndpoint,
         certificates, friendlyName);
 
     ArrayList<IDP> idps = new ArrayList<>(Collections.singleton(idp));
 
-    idpConnectorImpl.saveIDPs(idps, LatestTAG.LATEST_SPID);
+    idpConnectorImpl.saveIDPs(idps, LatestTAG.LATEST_SPID, String.valueOf(timestamp));
 
     IDP savedIdp = idpConnectorImpl.getIDPByEntityIDAndTimestamp(entityId,
         String.valueOf(LatestTAG.LATEST_SPID)).get();
@@ -203,19 +203,20 @@ class IDPConnectorImplTest {
 
     // then
 
-    IDP updatedIdp = new IDP(entityId, pointer, timestamp + 10, isActive, idpStatus, idpSSOEndpoint,
+    IDP updatedIdp = new IDP(entityId, pointer, isActive, idpStatus, idpSSOEndpoint,
         certificates, friendlyName);
 
     ArrayList<IDP> updatedIdps = new ArrayList<>(Collections.singleton(updatedIdp));
 
-    idpConnectorImpl.saveIDPs(updatedIdps, LatestTAG.LATEST_SPID);
+    idpConnectorImpl.saveIDPs(updatedIdps, LatestTAG.LATEST_SPID, String.valueOf(timestamp + 10));
 
     IDP newIdp = idpConnectorImpl.getIDPByEntityIDAndTimestamp(entityId,
         String.valueOf(LatestTAG.LATEST_SPID)).get();
 
     assertEquals(newIdp.getPointer(), String.valueOf(LatestTAG.LATEST_SPID));
-    assertTrue(idpConnectorImpl.getIDPByEntityIDAndTimestamp(entityId, String.valueOf(timestamp))
-        .isPresent());
+    assertTrue(
+        idpConnectorImpl.getIDPByEntityIDAndTimestamp(entityId, String.valueOf(timestamp + 10))
+            .isPresent());
 
 
   }

--- a/src/oneid/oneid-common/model/src/main/java/it/pagopa/oneid/common/model/IDP.java
+++ b/src/oneid/oneid-common/model/src/main/java/it/pagopa/oneid/common/model/IDP.java
@@ -32,10 +32,7 @@ public class IDP {
   })
   @NotNull
   private String pointer;
-
-  @NotNull
-  private long timestamp;
-
+  
   @NotNull
   private boolean isActive;
 

--- a/src/oneid/oneid-lambda-update-idp-metadata/src/main/java/it/pagopa/oneid/service/IDPMetadataServiceImpl.java
+++ b/src/oneid/oneid-lambda-update-idp-metadata/src/main/java/it/pagopa/oneid/service/IDPMetadataServiceImpl.java
@@ -56,7 +56,6 @@ public class IDPMetadataServiceImpl implements IDPMetadataService {
 
           // Initialize IDP fields
           IDP idp = new IDP();
-          idp.setTimestamp(idpS3FileDTO.getTimestamp());
           idp.setPointer(String.valueOf(idpS3FileDTO.getLatestTAG()));
           idp.setStatus(IDPStatus.OK);
           idp.setActive(true);
@@ -193,7 +192,8 @@ public class IDPMetadataServiceImpl implements IDPMetadataService {
 
   @Override
   public void updateIDPMetadata(ArrayList<IDP> idpMetadata, IdpS3FileDTO idpS3FileDTO) {
-    idpConnectorImpl.saveIDPs(idpMetadata, idpS3FileDTO.getLatestTAG());
+    idpConnectorImpl.saveIDPs(idpMetadata, idpS3FileDTO.getLatestTAG(),
+        String.valueOf(idpS3FileDTO.getTimestamp()));
   }
 
   @Override

--- a/src/oneid/oneid-lambda-update-idp-metadata/src/test/java/it/pagopa/oneid/service/IDPMetadataServiceImplTest.java
+++ b/src/oneid/oneid-lambda-update-idp-metadata/src/test/java/it/pagopa/oneid/service/IDPMetadataServiceImplTest.java
@@ -44,7 +44,8 @@ public class IDPMetadataServiceImplTest {
 
   @Test
   void updateIDPMetadata() {
-    Mockito.doNothing().when(idpConnectorImpl).saveIDPs(Mockito.any(), Mockito.any());
+    Mockito.doNothing().when(idpConnectorImpl)
+        .saveIDPs(Mockito.any(), Mockito.any(), Mockito.any());
 
     // then
     ArrayList<IDP> idpList = new ArrayList<>();


### PR DESCRIPTION
This **PR** aligns `IDPMetadata` pointer logic to IS timestamp data.

In this way it will be possible to rollback to previous IDP data using the same logic used by IS timestamp.