### PR TITLE
fix: add quarkus.http.test-port property

### DIFF
--- a/src/oneid/oneid-lambda-update-idp-metadata/src/main/resources/application.properties
+++ b/src/oneid/oneid-lambda-update-idp-metadata/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+quarkus.http.test-port=0
 quarkus.log.console.format=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c] (%t) [%C.%M] %s%e%n
 quarkus.dynamodb.devservices.enabled=false
 # s3


### PR DESCRIPTION
This **PR** solves the error `Quarkus BindException: Port(s) already bound: 8081: Address already in use` when running tests.