### PR TITLE
Test: improve oneid ecs core coverage

### DIFF
--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SAMLServiceImpl.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SAMLServiceImpl.java
@@ -154,7 +154,7 @@ public class SAMLServiceImpl implements SAMLService {
   @Override
   public void validateSAMLResponse(Response samlResponse, String entityID)
       throws OneIdentityException {
-    Log.debug("Starting SAML response validation");
+    Log.debug("start");
 
     Assertion assertion = extractAssertion(samlResponse);
     SubjectConfirmationData subjectConfirmationData = extractSubjectConfirmationData(assertion);

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/producers/XMLObjectProviderProducer.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/producers/XMLObjectProviderProducer.java
@@ -1,0 +1,15 @@
+package it.pagopa.oneid.service.producers;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
+import org.opensaml.core.xml.io.MarshallerFactory;
+
+public class XMLObjectProviderProducer {
+
+  @ApplicationScoped
+  @Produces
+  public MarshallerFactory produceMarshallerFactory() {
+    return XMLObjectProviderRegistrySupport.getMarshallerFactory();
+  }
+}

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/web/controller/OIDCControllerTest.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/web/controller/OIDCControllerTest.java
@@ -46,12 +46,15 @@ import org.mockito.Mockito;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.saml2.core.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @TestProfile(OIDCControllerTestProfile.class)
 @TestHTTPEndpoint(OIDCController.class)
 @QuarkusTest
 class OIDCControllerTest {
 
+  private static final Logger log = LoggerFactory.getLogger(OIDCControllerTest.class);
   private final String CLIENT_ID = "test";
 
 
@@ -67,7 +70,6 @@ class OIDCControllerTest {
 
   @Inject
   private SAMLUtilsExtendedCore samlUtilsExtendedCore;
-
 
   @Test
   @SneakyThrows
@@ -102,7 +104,6 @@ class OIDCControllerTest {
         .statusCode(200)
         .body(notNullValue());
   }
-
 
   //region /authorize
   @Test
@@ -331,6 +332,21 @@ class OIDCControllerTest {
     AuthorizationRequestDTOExtendedPost authorizationRequestDTOExtendedPost = getAuthorizationRequestDTOExtendedPost();
     authorizationRequestDTOExtendedPost.setScope("test");
 
+    // Mock "2. Check if idp exists"
+    IDP testIDP = IDP.builder()
+        .entityID("https://localhost:8443")
+        .certificates(Set.of(
+            "MIIEGDCCAwCgAwIBAgIJAOrYj9oLEJCwMA0GCSqGSIb3DQEBCwUAMGUxCzAJBgNVBAYTAklUMQ4wDAYDVQQIEwVJdGFseTENMAsGA1UEBxMEUm9tZTENMAsGA1UEChMEQWdJRDESMBAGA1UECxMJQWdJRCBURVNUMRQwEgYDVQQDEwthZ2lkLmdvdi5pdDAeFw0xOTA0MTExMDAyMDhaFw0yNTAzMDgxMDAyMDhaMGUxCzAJBgNVBAYTAklUMQ4wDAYDVQQIEwVJdGFseTENMAsGA1UEBxMEUm9tZTENMAsGA1UEChMEQWdJRDESMBAGA1UECxMJQWdJRCBURVNUMRQwEgYDVQQDEwthZ2lkLmdvdi5pdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK8kJVo+ugRrbbv9xhXCuVrqi4B7/MQzQc62ocwlFFujJNd4m1mXkUHFbgvwhRkQqo2DAmFeHiwCkJT3K1eeXIFhNFFroEzGPzONyekLpjNvmYIs1CFvirGOj0bkEiGaKEs+/umzGjxIhy5JQlqXE96y1+Izp2QhJimDK0/KNij8I1bzxseP0Ygc4SFveKS+7QO+PrLzWklEWGMs4DM5Zc3VRK7g4LWPWZhKdImC1rnS+/lEmHSvHisdVp/DJtbSrZwSYTRvTTz5IZDSq4kAzrDfpj16h7b3t3nFGc8UoY2Ro4tRZ3ahJ2r3b79yK6C5phY7CAANuW3gDdhVjiBNYs0CAwEAAaOByjCBxzAdBgNVHQ4EFgQU3/7kV2tbdFtphbSA4LH7+w8SkcwwgZcGA1UdIwSBjzCBjIAU3/7kV2tbdFtphbSA4LH7+w8SkcyhaaRnMGUxCzAJBgNVBAYTAklUMQ4wDAYDVQQIEwVJdGFseTENMAsGA1UEBxMEUm9tZTENMAsGA1UEChMEQWdJRDESMBAGA1UECxMJQWdJRCBURVNUMRQwEgYDVQQDEwthZ2lkLmdvdi5pdIIJAOrYj9oLEJCwMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAJNFqXg/V3aimJKUmUaqmQEEoSc3qvXFITvT5f5bKw9yk/NVhR6wndL+z/24h1OdRqs76blgH8k116qWNkkDtt0AlSjQOx5qvFYh1UviOjNdRI4WkYONSw+vuavcx+fB6O5JDHNmMhMySKTnmRqTkyhjrch7zaFIWUSV7hsBuxpqmrWDoLWdXbV3eFH3mINA5AoIY/m0bZtzZ7YNgiFWzxQgekpxd0vcTseMnCcXnsAlctdir0FoCZztxMuZjlBjwLTtM6Ry3/48LMM8Z+lw7NMciKLLTGQyU8XmKKSSOh0dGh5Lrlt5GxIIJkH81C0YimWebz8464QPL3RbLnTKg+c="))
+        .friendlyName("Test IDP")
+        .idpSSOEndpoints(Map.of("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+            "https://localhost:8443/samlsso"))
+        .isActive(true)
+        .pointer(String.valueOf(LatestTAG.LATEST_SPID))
+        .status(IDPStatus.OK)
+        .build();
+
+    Mockito.when(samlServiceImpl.getIDPFromEntityID(Mockito.any()))
+        .thenReturn(Optional.of(testIDP));
     //then
     given()
         .contentType("application/x-www-form-urlencoded")
@@ -359,6 +375,21 @@ class OIDCControllerTest {
     AuthorizationRequestDTOExtendedPost authorizationRequestDTOExtendedPost = getAuthorizationRequestDTOExtendedPost();
     authorizationRequestDTOExtendedPost.setResponseType(ResponseType.NONE);
 
+    // Mock "2. Check if idp exists"
+    IDP testIDP = IDP.builder()
+        .entityID("https://localhost:8443")
+        .certificates(Set.of(
+            "MIIEGDCCAwCgAwIBAgIJAOrYj9oLEJCwMA0GCSqGSIb3DQEBCwUAMGUxCzAJBgNVBAYTAklUMQ4wDAYDVQQIEwVJdGFseTENMAsGA1UEBxMEUm9tZTENMAsGA1UEChMEQWdJRDESMBAGA1UECxMJQWdJRCBURVNUMRQwEgYDVQQDEwthZ2lkLmdvdi5pdDAeFw0xOTA0MTExMDAyMDhaFw0yNTAzMDgxMDAyMDhaMGUxCzAJBgNVBAYTAklUMQ4wDAYDVQQIEwVJdGFseTENMAsGA1UEBxMEUm9tZTENMAsGA1UEChMEQWdJRDESMBAGA1UECxMJQWdJRCBURVNUMRQwEgYDVQQDEwthZ2lkLmdvdi5pdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK8kJVo+ugRrbbv9xhXCuVrqi4B7/MQzQc62ocwlFFujJNd4m1mXkUHFbgvwhRkQqo2DAmFeHiwCkJT3K1eeXIFhNFFroEzGPzONyekLpjNvmYIs1CFvirGOj0bkEiGaKEs+/umzGjxIhy5JQlqXE96y1+Izp2QhJimDK0/KNij8I1bzxseP0Ygc4SFveKS+7QO+PrLzWklEWGMs4DM5Zc3VRK7g4LWPWZhKdImC1rnS+/lEmHSvHisdVp/DJtbSrZwSYTRvTTz5IZDSq4kAzrDfpj16h7b3t3nFGc8UoY2Ro4tRZ3ahJ2r3b79yK6C5phY7CAANuW3gDdhVjiBNYs0CAwEAAaOByjCBxzAdBgNVHQ4EFgQU3/7kV2tbdFtphbSA4LH7+w8SkcwwgZcGA1UdIwSBjzCBjIAU3/7kV2tbdFtphbSA4LH7+w8SkcyhaaRnMGUxCzAJBgNVBAYTAklUMQ4wDAYDVQQIEwVJdGFseTENMAsGA1UEBxMEUm9tZTENMAsGA1UEChMEQWdJRDESMBAGA1UECxMJQWdJRCBURVNUMRQwEgYDVQQDEwthZ2lkLmdvdi5pdIIJAOrYj9oLEJCwMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAJNFqXg/V3aimJKUmUaqmQEEoSc3qvXFITvT5f5bKw9yk/NVhR6wndL+z/24h1OdRqs76blgH8k116qWNkkDtt0AlSjQOx5qvFYh1UviOjNdRI4WkYONSw+vuavcx+fB6O5JDHNmMhMySKTnmRqTkyhjrch7zaFIWUSV7hsBuxpqmrWDoLWdXbV3eFH3mINA5AoIY/m0bZtzZ7YNgiFWzxQgekpxd0vcTseMnCcXnsAlctdir0FoCZztxMuZjlBjwLTtM6Ry3/48LMM8Z+lw7NMciKLLTGQyU8XmKKSSOh0dGh5Lrlt5GxIIJkH81C0YimWebz8464QPL3RbLnTKg+c="))
+        .friendlyName("Test IDP")
+        .idpSSOEndpoints(Map.of("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+            "https://localhost:8443/samlsso"))
+        .isActive(true)
+        .pointer(String.valueOf(LatestTAG.LATEST_SPID))
+        .status(IDPStatus.OK)
+        .build();
+
+    Mockito.when(samlServiceImpl.getIDPFromEntityID(Mockito.any()))
+        .thenReturn(Optional.of(testIDP));
     //then
     given()
         .contentType("application/x-www-form-urlencoded")
@@ -386,6 +417,21 @@ class OIDCControllerTest {
     // AuthorizationDTO Creation
     AuthorizationRequestDTOExtendedPost authorizationRequestDTOExtendedPost = getAuthorizationRequestDTOExtendedPost();
 
+    // Mock "2. Check if idp exists"
+    IDP testIDP = IDP.builder()
+        .entityID("https://localhost:8443")
+        .certificates(Set.of(
+            "MIIEGDCCAwCgAwIBAgIJAOrYj9oLEJCwMA0GCSqGSIb3DQEBCwUAMGUxCzAJBgNVBAYTAklUMQ4wDAYDVQQIEwVJdGFseTENMAsGA1UEBxMEUm9tZTENMAsGA1UEChMEQWdJRDESMBAGA1UECxMJQWdJRCBURVNUMRQwEgYDVQQDEwthZ2lkLmdvdi5pdDAeFw0xOTA0MTExMDAyMDhaFw0yNTAzMDgxMDAyMDhaMGUxCzAJBgNVBAYTAklUMQ4wDAYDVQQIEwVJdGFseTENMAsGA1UEBxMEUm9tZTENMAsGA1UEChMEQWdJRDESMBAGA1UECxMJQWdJRCBURVNUMRQwEgYDVQQDEwthZ2lkLmdvdi5pdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK8kJVo+ugRrbbv9xhXCuVrqi4B7/MQzQc62ocwlFFujJNd4m1mXkUHFbgvwhRkQqo2DAmFeHiwCkJT3K1eeXIFhNFFroEzGPzONyekLpjNvmYIs1CFvirGOj0bkEiGaKEs+/umzGjxIhy5JQlqXE96y1+Izp2QhJimDK0/KNij8I1bzxseP0Ygc4SFveKS+7QO+PrLzWklEWGMs4DM5Zc3VRK7g4LWPWZhKdImC1rnS+/lEmHSvHisdVp/DJtbSrZwSYTRvTTz5IZDSq4kAzrDfpj16h7b3t3nFGc8UoY2Ro4tRZ3ahJ2r3b79yK6C5phY7CAANuW3gDdhVjiBNYs0CAwEAAaOByjCBxzAdBgNVHQ4EFgQU3/7kV2tbdFtphbSA4LH7+w8SkcwwgZcGA1UdIwSBjzCBjIAU3/7kV2tbdFtphbSA4LH7+w8SkcyhaaRnMGUxCzAJBgNVBAYTAklUMQ4wDAYDVQQIEwVJdGFseTENMAsGA1UEBxMEUm9tZTENMAsGA1UEChMEQWdJRDESMBAGA1UECxMJQWdJRCBURVNUMRQwEgYDVQQDEwthZ2lkLmdvdi5pdIIJAOrYj9oLEJCwMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAJNFqXg/V3aimJKUmUaqmQEEoSc3qvXFITvT5f5bKw9yk/NVhR6wndL+z/24h1OdRqs76blgH8k116qWNkkDtt0AlSjQOx5qvFYh1UviOjNdRI4WkYONSw+vuavcx+fB6O5JDHNmMhMySKTnmRqTkyhjrch7zaFIWUSV7hsBuxpqmrWDoLWdXbV3eFH3mINA5AoIY/m0bZtzZ7YNgiFWzxQgekpxd0vcTseMnCcXnsAlctdir0FoCZztxMuZjlBjwLTtM6Ry3/48LMM8Z+lw7NMciKLLTGQyU8XmKKSSOh0dGh5Lrlt5GxIIJkH81C0YimWebz8464QPL3RbLnTKg+c="))
+        .friendlyName("Test IDP")
+        .idpSSOEndpoints(Map.of("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+            "https://localhost:8443/samlsso"))
+        .isActive(true)
+        .pointer(String.valueOf(LatestTAG.LATEST_SPID))
+        .status(IDPStatus.OK)
+        .build();
+
+    Mockito.when(samlServiceImpl.getIDPFromEntityID(Mockito.any()))
+        .thenReturn(Optional.of(testIDP));
     // Mock "6. Create SAML Authn Request using SAMLServiceImpl" with error
     Mockito.when(
             samlServiceImpl.buildAuthnRequest(Mockito.anyString(), Mockito.anyInt(), Mockito.anyInt(),
@@ -420,6 +466,21 @@ class OIDCControllerTest {
     AuthorizationRequestDTOExtendedPost authorizationRequestDTOExtendedPost = getAuthorizationRequestDTOExtendedPost();
     authorizationRequestDTOExtendedPost.setIdp("testSessionException");
 
+    // Mock "2. Check if idp exists"
+    IDP testIDP = IDP.builder()
+        .entityID("https://localhost:8443")
+        .certificates(Set.of(
+            "MIIEGDCCAwCgAwIBAgIJAOrYj9oLEJCwMA0GCSqGSIb3DQEBCwUAMGUxCzAJBgNVBAYTAklUMQ4wDAYDVQQIEwVJdGFseTENMAsGA1UEBxMEUm9tZTENMAsGA1UEChMEQWdJRDESMBAGA1UECxMJQWdJRCBURVNUMRQwEgYDVQQDEwthZ2lkLmdvdi5pdDAeFw0xOTA0MTExMDAyMDhaFw0yNTAzMDgxMDAyMDhaMGUxCzAJBgNVBAYTAklUMQ4wDAYDVQQIEwVJdGFseTENMAsGA1UEBxMEUm9tZTENMAsGA1UEChMEQWdJRDESMBAGA1UECxMJQWdJRCBURVNUMRQwEgYDVQQDEwthZ2lkLmdvdi5pdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK8kJVo+ugRrbbv9xhXCuVrqi4B7/MQzQc62ocwlFFujJNd4m1mXkUHFbgvwhRkQqo2DAmFeHiwCkJT3K1eeXIFhNFFroEzGPzONyekLpjNvmYIs1CFvirGOj0bkEiGaKEs+/umzGjxIhy5JQlqXE96y1+Izp2QhJimDK0/KNij8I1bzxseP0Ygc4SFveKS+7QO+PrLzWklEWGMs4DM5Zc3VRK7g4LWPWZhKdImC1rnS+/lEmHSvHisdVp/DJtbSrZwSYTRvTTz5IZDSq4kAzrDfpj16h7b3t3nFGc8UoY2Ro4tRZ3ahJ2r3b79yK6C5phY7CAANuW3gDdhVjiBNYs0CAwEAAaOByjCBxzAdBgNVHQ4EFgQU3/7kV2tbdFtphbSA4LH7+w8SkcwwgZcGA1UdIwSBjzCBjIAU3/7kV2tbdFtphbSA4LH7+w8SkcyhaaRnMGUxCzAJBgNVBAYTAklUMQ4wDAYDVQQIEwVJdGFseTENMAsGA1UEBxMEUm9tZTENMAsGA1UEChMEQWdJRDESMBAGA1UECxMJQWdJRCBURVNUMRQwEgYDVQQDEwthZ2lkLmdvdi5pdIIJAOrYj9oLEJCwMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAJNFqXg/V3aimJKUmUaqmQEEoSc3qvXFITvT5f5bKw9yk/NVhR6wndL+z/24h1OdRqs76blgH8k116qWNkkDtt0AlSjQOx5qvFYh1UviOjNdRI4WkYONSw+vuavcx+fB6O5JDHNmMhMySKTnmRqTkyhjrch7zaFIWUSV7hsBuxpqmrWDoLWdXbV3eFH3mINA5AoIY/m0bZtzZ7YNgiFWzxQgekpxd0vcTseMnCcXnsAlctdir0FoCZztxMuZjlBjwLTtM6Ry3/48LMM8Z+lw7NMciKLLTGQyU8XmKKSSOh0dGh5Lrlt5GxIIJkH81C0YimWebz8464QPL3RbLnTKg+c="))
+        .friendlyName("Test IDP")
+        .idpSSOEndpoints(Map.of("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+            "https://localhost:8443/samlsso"))
+        .isActive(true)
+        .pointer(String.valueOf(LatestTAG.LATEST_SPID))
+        .status(IDPStatus.OK)
+        .build();
+
+    Mockito.when(samlServiceImpl.getIDPFromEntityID(Mockito.any()))
+        .thenReturn(Optional.of(testIDP));
     // Mock "6. Create SAML Authn Request using SAMLServiceImpl"
     AuthnRequest authnRequest = buildAuthnRequest("https://localhost:8443");
 

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/web/controller/OIDCControllerTest.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/web/controller/OIDCControllerTest.java
@@ -46,15 +46,12 @@ import org.mockito.Mockito;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.saml2.core.Response;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @TestProfile(OIDCControllerTestProfile.class)
 @TestHTTPEndpoint(OIDCController.class)
 @QuarkusTest
 class OIDCControllerTest {
 
-  private static final Logger log = LoggerFactory.getLogger(OIDCControllerTest.class);
   private final String CLIENT_ID = "test";
 
 

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/web/converter/StringToEnumConverterProviderTest.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/web/converter/StringToEnumConverterProviderTest.java
@@ -1,0 +1,63 @@
+package it.pagopa.oneid.web.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import io.quarkus.test.junit.QuarkusTest;
+import it.pagopa.oneid.common.model.enums.GrantType;
+import it.pagopa.oneid.model.session.enums.ResponseType;
+import jakarta.ws.rs.ext.ParamConverter;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class StringToEnumConverterProviderTest {
+
+  private final StringToEnumConverterProvider provider = new StringToEnumConverterProvider();
+
+  @Test
+  void testGetConverter_GrantType() {
+    ParamConverter<GrantType> converter = provider.getConverter(GrantType.class, null, null);
+    assertNotNull(converter);
+
+    // Test fromString with valid value
+    assertEquals(GrantType.AUTHORIZATION_CODE, converter.fromString("authorization_code"));
+
+    // Test fromString with invalid value
+    assertNull(converter.fromString("invalid_value"));
+
+    // Test toString with non-null value
+    assertEquals("AUTHORIZATION_CODE", converter.toString(GrantType.AUTHORIZATION_CODE));
+
+    // Test toString with null value
+    assertNull(converter.toString(null));
+  }
+
+  @Test
+  void testGetConverter_ResponseType() {
+    ParamConverter<ResponseType> converter = provider.getConverter(ResponseType.class, null, null);
+    assertNotNull(converter);
+
+    // Test fromString with valid value
+    assertEquals(ResponseType.CODE, converter.fromString("code"));
+
+    // Test fromString with invalid value
+    assertNull(converter.fromString("invalid_value"));
+
+    // Test toString with non-null value
+    assertEquals("CODE", converter.toString(ResponseType.CODE));
+
+    // Test toString with null value
+    assertNull(converter.toString(null));
+  }
+
+  @Test
+  void testGetConverter_OtherEnum() {
+    // Test with an enum type that is not handled
+    ParamConverter<OtherEnum> converter = provider.getConverter(OtherEnum.class, null, null);
+    assertNull(converter);
+  }
+
+  enum OtherEnum {
+    VALUE1, VALUE2;
+  }
+}

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/web/utils/WebUtilsTest.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/web/utils/WebUtilsTest.java
@@ -4,14 +4,11 @@ import static it.pagopa.oneid.web.utils.WebUtils.getElementValueFromAuthnRequest
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import it.pagopa.oneid.service.SAMLServiceImpl;
 import it.pagopa.oneid.service.mock.X509CredentialTestProfile;
 import jakarta.inject.Inject;
-import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import org.w3c.dom.Node;
 
 @QuarkusTest
 @TestProfile(X509CredentialTestProfile.class)
@@ -55,20 +51,6 @@ class WebUtilsTest {
 
   @Test
   @SneakyThrows
-  void getStringValue_TransformerException() {
-    // given
-    DocumentBuilderFactory documentFactory = DocumentBuilderFactory.newInstance();
-    DocumentBuilder documentBuilder = documentFactory.newDocumentBuilder();
-    Document document = documentBuilder.newDocument();
-    Node invalidNode = document.createProcessingInstruction("xml", "version='1.0'");
-
-    // then
-    assertThrows(RuntimeException.class,
-        () -> WebUtils.getStringValue((Element) invalidNode));
-  }
-
-  @Test
-  @SneakyThrows
   void getElementValueFromAuthnRequest_success() {
     // given
     //TODO remove authnRequest creation based on samlServiceImpl method
@@ -78,17 +60,5 @@ class WebUtilsTest {
 
     // then
     assertDoesNotThrow(() -> getElementValueFromAuthnRequest(authnRequest));
-  }
-
-  @Test
-  @SneakyThrows
-  void getElementValueFromAuthnRequest_MarshallingException() {
-    // given
-    AuthnRequest authnRequest = mock(AuthnRequest.class);
-
-    // then
-    RuntimeException exception = assertThrows(RuntimeException.class,
-        () -> getElementValueFromAuthnRequest(authnRequest));
-
   }
 }

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/web/validator/AuthenticationRequestValidatorTest.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/web/validator/AuthenticationRequestValidatorTest.java
@@ -1,0 +1,150 @@
+package it.pagopa.oneid.web.validator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import io.quarkus.test.junit.QuarkusTest;
+import it.pagopa.oneid.common.model.Client;
+import it.pagopa.oneid.common.model.exception.AuthorizationErrorException;
+import it.pagopa.oneid.common.model.exception.enums.ErrorCode;
+import it.pagopa.oneid.exception.GenericHTMLException;
+import it.pagopa.oneid.model.session.enums.ResponseType;
+import it.pagopa.oneid.web.dto.AuthorizationRequestDTOExtendedGet;
+import it.pagopa.oneid.web.dto.AuthorizationRequestDTOExtendedPost;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+@QuarkusTest
+class AuthenticationRequestValidatorTest {
+
+  private AuthenticationRequestValidator validator;
+  private Map<String, Client> clientsMap;
+
+  @BeforeEach
+  void setUp() {
+    validator = new AuthenticationRequestValidator();
+    clientsMap = new HashMap<>();
+    validator.clientsMap = clientsMap;
+  }
+
+  @Test
+  void testValidGetRequest() {
+    AuthorizationRequestDTOExtendedGet request = mock(AuthorizationRequestDTOExtendedGet.class);
+    when(request.getResponseType()).thenReturn(ResponseType.CODE);
+    when(request.getRedirectUri()).thenReturn("http://callback");
+    when(request.getClientId()).thenReturn("client1");
+    when(request.getState()).thenReturn("state");
+    when(request.getIdp()).thenReturn("idp1");
+
+    Client client = mock(Client.class);
+    when(client.getCallbackURI()).thenReturn(Set.of("http://callback"));
+    clientsMap.put("client1", client);
+
+    assertTrue(validator.isValid(request, Mockito.mock(ConstraintValidatorContext.class)));
+  }
+
+  @Test
+  void testValidPostRequest() {
+    AuthorizationRequestDTOExtendedPost request = mock(AuthorizationRequestDTOExtendedPost.class);
+    when(request.getResponseType()).thenReturn(ResponseType.CODE);
+    when(request.getRedirectUri()).thenReturn("http://callback");
+    when(request.getClientId()).thenReturn("client2");
+    when(request.getState()).thenReturn("state");
+    when(request.getIdp()).thenReturn("idp1");
+
+    Client client = mock(Client.class);
+    when(client.getCallbackURI()).thenReturn(Set.of("http://callback"));
+    clientsMap.put("client2", client);
+
+    assertTrue(validator.isValid(request, Mockito.mock(ConstraintValidatorContext.class)));
+  }
+
+  @Test
+  void testInvalidResponseTypeWithValidCallback() {
+    AuthorizationRequestDTOExtendedGet request = mock(AuthorizationRequestDTOExtendedGet.class);
+    when(request.getResponseType()).thenReturn(null);
+    when(request.getRedirectUri()).thenReturn("http://callback");
+    when(request.getClientId()).thenReturn("client1");
+    when(request.getState()).thenReturn("state");
+    when(request.getIdp()).thenReturn("idp1");
+
+    Client client = mock(Client.class);
+    when(client.getCallbackURI()).thenReturn(Set.of("http://callback"));
+    clientsMap.put("client1", client);
+
+    Exception exception = assertThrows(AuthorizationErrorException.class,
+        () -> validator.isValid(request, Mockito.mock(ConstraintValidatorContext.class)));
+
+    assertEquals(ErrorCode.AUTHORIZATION_ERROR_RESPONSE_TYPE.getErrorMessage(),
+        exception.getMessage());
+  }
+
+  @Test
+  void testInvalidIdpWithValidCallback() {
+    AuthorizationRequestDTOExtendedGet request = mock(AuthorizationRequestDTOExtendedGet.class);
+    when(request.getResponseType()).thenReturn(ResponseType.CODE);
+    when(request.getRedirectUri()).thenReturn("http://callback");
+    when(request.getClientId()).thenReturn("client1");
+    when(request.getState()).thenReturn("state");
+    when(request.getIdp()).thenReturn(null);
+
+    Client client = mock(Client.class);
+    when(client.getCallbackURI()).thenReturn(Set.of("http://callback"));
+    clientsMap.put("client1", client);
+
+    Exception exception = assertThrows(AuthorizationErrorException.class,
+        () -> validator.isValid(request, Mockito.mock(ConstraintValidatorContext.class)));
+
+    assertEquals(ErrorCode.AUTHORIZATION_ERROR_IDP.getErrorMessage(), exception.getMessage());
+  }
+
+  @Test
+  void testInvalidIdpWithInvalidClient() {
+    AuthorizationRequestDTOExtendedGet request = mock(AuthorizationRequestDTOExtendedGet.class);
+    when(request.getResponseType()).thenReturn(ResponseType.CODE);
+    when(request.getRedirectUri()).thenReturn("http://callback");
+    when(request.getClientId()).thenReturn("client3");
+    when(request.getState()).thenReturn("state");
+    when(request.getIdp()).thenReturn(null);
+
+    Client client = mock(Client.class);
+    when(client.getCallbackURI()).thenReturn(Set.of("http://callback"));
+    clientsMap.put("client1", client);
+
+    Exception exception = assertThrows(GenericHTMLException.class,
+        () -> validator.isValid(request, Mockito.mock(ConstraintValidatorContext.class)));
+
+    assertEquals(ErrorCode.AUTHORIZATION_ERROR_IDP, ErrorCode.valueOf(exception.getMessage()));
+  }
+
+  @Test
+  void testInvalidRequestTypeThrowsException() {
+    Exception exception = assertThrows(GenericHTMLException.class,
+        () -> validator.isValid(new Object(), Mockito.mock(ConstraintValidatorContext.class)));
+
+    assertEquals(ErrorCode.GENERIC_HTML_ERROR, ErrorCode.valueOf(exception.getMessage()));
+  }
+
+  @Test
+  void testNullCallbackUriAndClient() {
+    AuthorizationRequestDTOExtendedGet request = mock(AuthorizationRequestDTOExtendedGet.class);
+    when(request.getResponseType()).thenReturn(null);
+    when(request.getRedirectUri()).thenReturn(null);
+    when(request.getClientId()).thenReturn("client1");
+    when(request.getState()).thenReturn("state");
+    when(request.getIdp()).thenReturn(null);
+
+    Exception exception = assertThrows(GenericHTMLException.class,
+        () -> validator.isValid(request, Mockito.mock(ConstraintValidatorContext.class)));
+
+    assertEquals(ErrorCode.AUTHORIZATION_ERROR_RESPONSE_TYPE,
+        ErrorCode.valueOf(exception.getMessage()));
+  }
+}


### PR DESCRIPTION
This **PR** improves `oneid-ecs-core` module code coverage.

Small refactoring needed to improve code testability mostly using _Dependency Injection_ pattern.