### PR TITLE
Fix: add clock skew handling

### DIFF
--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SAMLServiceImpl.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SAMLServiceImpl.java
@@ -92,6 +92,9 @@ public class SAMLServiceImpl implements SAMLService {
   @ConfigProperty(name = "acs_url")
   String ACS_URL;
 
+  @ConfigProperty(name = "clock_skew_ms")
+  long CLOCK_SKEW_MS;
+
 
   @Inject
   SAMLServiceImpl(Clock clock) {
@@ -283,7 +286,7 @@ public class SAMLServiceImpl implements SAMLService {
 
       throw new SAMLValidationException(ErrorCode.IDP_ERROR_ISSUE_INSTANT_AFTER_REQUEST);
     }
-    if (!issueInstant.isBefore(Instant.now(clock))) {
+    if (!issueInstant.isBefore(Instant.now(clock).plusMillis(CLOCK_SKEW_MS))) {
 
       throw new SAMLValidationException(ErrorCode.IDP_ERROR_ISSUE_INSTANT_IN_THE_FUTURE);
     }
@@ -316,15 +319,13 @@ public class SAMLServiceImpl implements SAMLService {
   }
 
   private void checkNotBefore(Instant notBefore) {
-    if (Instant.now(clock).compareTo(notBefore) <= 0) {
-
-      throw new SAMLValidationException(ErrorCode.IDP_ERROR_NOT_BEFORE_NOT_FOUND);
+    if (Instant.now(clock).plusMillis(CLOCK_SKEW_MS).compareTo(notBefore) <= 0) {
+      throw new SAMLValidationException(ErrorCode.IDP_ERROR_NOT_BEFORE_IN_THE_FUTURE);
     }
   }
 
   private void checkNotOnOrAfter(Instant notOnOrAfter) {
-    if (Instant.now(clock).compareTo(notOnOrAfter) >= 0) {
-
+    if (Instant.now(clock).minusMillis(CLOCK_SKEW_MS).compareTo(notOnOrAfter) >= 0) {
       throw new SAMLValidationException(ErrorCode.IDP_ERROR_NOT_ON_OR_AFTER_EXPIRED);
     }
   }

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SAMLServiceImpl.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SAMLServiceImpl.java
@@ -286,8 +286,11 @@ public class SAMLServiceImpl implements SAMLService {
 
       throw new SAMLValidationException(ErrorCode.IDP_ERROR_ISSUE_INSTANT_AFTER_REQUEST);
     }
-    if (!issueInstant.isBefore(Instant.now(clock).plusMillis(CLOCK_SKEW_MS))) {
-
+    Instant instant = Instant.now(clock).plusMillis(CLOCK_SKEW_MS);
+    if (!issueInstant.isBefore(instant)) {
+      // TODO: remove this log and compact if statement without defining external variable
+      Log.error(
+          "isBefore not valid -> IDP issueInstant: " + issueInstant + "OI instant: " + instant);
       throw new SAMLValidationException(ErrorCode.IDP_ERROR_ISSUE_INSTANT_IN_THE_FUTURE);
     }
   }

--- a/src/oneid/oneid-ecs-core/src/main/resources/application.properties
+++ b/src/oneid/oneid-ecs-core/src/main/resources/application.properties
@@ -33,6 +33,7 @@ cie_entity_id=${CIE_ENTITY_ID:https://preproduzione.idserver.servizicie.interno.
 base_path=${BASE_PATH:localhost:8080}
 entity_id=${ENTITY_ID:localhost:8080/pub-op-full}
 acs_url=${ACS_URL:/saml/acs}
+clock_skew_ms=${CLOCK_SKEW_MS:3000}
 #endregion
 #region Log
 quarkus.log.console.format=%d{yyyy-MM-dd HH:mm:ss} %-5p (%t) [%C.%M] %s%e%n

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/SAMLServiceImplTest.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/SAMLServiceImplTest.java
@@ -29,6 +29,7 @@ import static it.pagopa.oneid.common.model.exception.enums.ErrorCode.IDP_ERROR_I
 import static it.pagopa.oneid.common.model.exception.enums.ErrorCode.IDP_ERROR_ISSUER_NOT_FOUND;
 import static it.pagopa.oneid.common.model.exception.enums.ErrorCode.IDP_ERROR_ISSUER_VALUE_BLANK;
 import static it.pagopa.oneid.common.model.exception.enums.ErrorCode.IDP_ERROR_MISSING_CONDITIONS;
+import static it.pagopa.oneid.common.model.exception.enums.ErrorCode.IDP_ERROR_NOT_BEFORE_IN_THE_FUTURE;
 import static it.pagopa.oneid.common.model.exception.enums.ErrorCode.IDP_ERROR_NOT_BEFORE_NOT_FOUND;
 import static it.pagopa.oneid.common.model.exception.enums.ErrorCode.IDP_ERROR_NOT_ON_OR_AFTER_EXPIRED;
 import static it.pagopa.oneid.common.model.exception.enums.ErrorCode.IDP_ERROR_NOT_ON_OR_AFTER_NOT_FOUND;
@@ -2687,7 +2688,7 @@ public class SAMLServiceImplTest {
                 Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
 
     assertTrue(
-        exception.getMessage().contains(IDP_ERROR_NOT_BEFORE_NOT_FOUND.getErrorMessage()));
+        exception.getMessage().contains(IDP_ERROR_NOT_BEFORE_IN_THE_FUTURE.getErrorMessage()));
   }
 
   @Test


### PR DESCRIPTION
This **PR** adds `3s` of tolerance when validating `issueInstant`, `notOnOrAfter` and `notBefore` SAML Properties during `SAMLResponse` validation.

This is needed to resolve possible sync problem between `SP` (OI) and `IDPs` clock.