### PR TITLE
chore: remov uat and prod envs from lambda idp mock deploy github action

### DIFF
--- a/.github/workflows/deploy-lambda-idp-mock.yml
+++ b/.github/workflows/deploy-lambda-idp-mock.yml
@@ -38,7 +38,7 @@ jobs:
               matrixStringifiedObject="{\"include\":[{\"environment\":\"${{ github.event.inputs.environment }}\", \"region\":\"eu-south-1\"}]}"
             fi
           else
-            matrixStringifiedObject="{\"include\":[{\"environment\":\"dev\", \"region\":\"eu-south-1\"}, {\"environment\":\"uat\", \"region\":\"eu-south-1\"}, {\"environment\":\"prod\", \"region\":\"eu-south-1\"}, {\"environment\":\"prod\", \"region\":\"eu-central-1\"}]}"
+            matrixStringifiedObject="{\"include\":[{\"environment\":\"dev\", \"region\":\"eu-south-1\"}]}"
           fi
 
           echo "matrix=$matrixStringifiedObject" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Remove `uat` and `prod` environment from deploy action.

We don't need to deploy this lambda to environments different from `dev.`