### PR TITLE
feat: update amazon-ecs-deploy-task-definition action version to 2.2.0

### DIFF
--- a/.github/workflows/deploy-oneid-core.yml
+++ b/.github/workflows/deploy-oneid-core.yml
@@ -141,7 +141,7 @@ jobs:
           image: "${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY }}:${{ github.sha }}"
 
       - name: Deploy Amazon ECS task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@df9643053eda01f169e64a0e60233aacca83799a # v1.4.11
+        uses: aws-actions/amazon-ecs-deploy-task-definition@0e82244a9c6dac43d70151a94c67ebc4bab18fc5 # v2.2.0
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
           service: oneid-${{ env.REGION_SHORT }}-${{ env.ENV_SHORT }}-core


### PR DESCRIPTION
This **PR** updates the `amazon-ecs-deploy-task-definition` action to `2.2.0`.

This update fixes the error [`Unexpected key 'enableFaultInjection' found in params`](https://repost.aws/questions/QUoSrPMS_LQMS3s03q90xrIg/unexpected-key-enablefaultinjection-found-in-params) encountered [here](https://github.com/pagopa/oneidentity/actions/runs/12687063366).