### PR TITLE
refactor: Add update method instead of delete

### DIFF
--- a/src/oneid/oneid-lambda-is-gh-integration/src/main/java/it/pagopa/oneid/connector/GitHubConnectorImpl.java
+++ b/src/oneid/oneid-lambda-is-gh-integration/src/main/java/it/pagopa/oneid/connector/GitHubConnectorImpl.java
@@ -1,6 +1,5 @@
 package it.pagopa.oneid.connector;
 
-import static it.pagopa.oneid.utils.Constants.METADATA_BASE_PATH;
 import io.quarkus.logging.Log;
 import it.pagopa.oneid.common.utils.logging.CustomLogging;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -30,23 +29,10 @@ public class GitHubConnectorImpl implements GitHubConnector {
       throw new RuntimeException(e);
     }
 
-    GHContent existingFile = findFileInDirectory(METADATA_BASE_PATH, idpType,
-        branchName);
+    // Create or update metadata file
+    createOrUpdateFile(fileContent, metadataPath, branchName, idpType);
+    Log.debug("successfully created/updated metadata file");
 
-    if (existingFile != null) {
-      // update the existing file if it exists
-      try {
-        existingFile.update(fileContent, "feat: update metadata file for " + idpType, branchName);
-      } catch (IOException e) {
-        Log.error("error updating existing metadata file: " + e.getMessage());
-        throw new RuntimeException(e);
-      }
-      Log.debug("updated metadata file for " + idpType);
-    } else {
-      // Create a new file with updated content
-      createFileWithUpdatedContent(fileContent, metadataPath, branchName, idpType);
-      Log.debug("successfully created new metadata file");
-    }
   }
 
 
@@ -64,7 +50,7 @@ public class GitHubConnectorImpl implements GitHubConnector {
     }
   }
 
-  private void createFileWithUpdatedContent(String fileContent, String metadataPath,
+  private void createOrUpdateFile(String fileContent, String metadataPath,
       String branchName,
       String idpType) {
     try {
@@ -74,7 +60,7 @@ public class GitHubConnectorImpl implements GitHubConnector {
           .path(metadataPath)
           .branch(branchName)
           .commit();
-      Log.debug("created file metadata for " + idpType);
+      Log.debug("created/updated file metadata for " + idpType);
     } catch (IOException e) {
       Log.error("error creating commit with new metadata: " + e.getMessage());
       throw new RuntimeException(e);

--- a/src/oneid/oneid-lambda-is-gh-integration/src/main/java/it/pagopa/oneid/connector/GitHubConnectorImpl.java
+++ b/src/oneid/oneid-lambda-is-gh-integration/src/main/java/it/pagopa/oneid/connector/GitHubConnectorImpl.java
@@ -34,19 +34,19 @@ public class GitHubConnectorImpl implements GitHubConnector {
         branchName);
 
     if (existingFile != null) {
-      // delete the existing file if it exists
+      // update the existing file if it exists
       try {
-        existingFile.delete("feat: remove metadata file for " + idpType, branchName);
+        existingFile.update(fileContent, "feat: update metadata file for " + idpType, branchName);
       } catch (IOException e) {
-        Log.error("error deleting existing metadata file: " + e.getMessage());
+        Log.error("error updating existing metadata file: " + e.getMessage());
         throw new RuntimeException(e);
       }
-      Log.debug("deleted metadata file for " + idpType);
+      Log.debug("updated metadata file for " + idpType);
+    } else {
+      // Create a new file with updated content
+      createFileWithUpdatedContent(fileContent, metadataPath, branchName, idpType);
+      Log.debug("successfully created new metadata file");
     }
-
-    // Create a new file with updated content
-    createFileWithUpdatedContent(fileContent, metadataPath, branchName, idpType);
-    Log.debug("successfully created new metadata file");
   }
 
 

--- a/src/oneid/oneid-lambda-is-gh-integration/src/test/java/it/pagopa/oneid/connector/GitHubConnectorImplTest.java
+++ b/src/oneid/oneid-lambda-is-gh-integration/src/test/java/it/pagopa/oneid/connector/GitHubConnectorImplTest.java
@@ -76,14 +76,14 @@ public class GitHubConnectorImplTest {
 
   @Test
   @SneakyThrows
-  void createBranchAndCommit_errorDeletingExistingFile() {
+  void createBranchAndCommit_errorUpdatingExistingFile() {
 
     GHContent content = mock(GHContent.class);
     when(content.getName()).thenReturn("spid");
 
     List<GHContent> contentList = new ArrayList<>();
     contentList.add(content);
-    when(content.delete(anyString(), anyString())).thenThrow(IOException.class);
+    when(content.update(anyString(), anyString(), anyString())).thenThrow(IOException.class);
     when(repository.getDirectoryContent(any(), any())).thenReturn(contentList);
 
     Executable executable = () -> gitHubConnectorImpl.createBranchAndCommit("test-branch",

--- a/src/oneid/oneid-lambda-is-gh-integration/src/test/java/it/pagopa/oneid/connector/GitHubConnectorImplTest.java
+++ b/src/oneid/oneid-lambda-is-gh-integration/src/test/java/it/pagopa/oneid/connector/GitHubConnectorImplTest.java
@@ -76,24 +76,6 @@ public class GitHubConnectorImplTest {
 
   @Test
   @SneakyThrows
-  void createBranchAndCommit_errorUpdatingExistingFile() {
-
-    GHContent content = mock(GHContent.class);
-    when(content.getName()).thenReturn("spid");
-
-    List<GHContent> contentList = new ArrayList<>();
-    contentList.add(content);
-    when(content.update(anyString(), anyString(), anyString())).thenThrow(IOException.class);
-    when(repository.getDirectoryContent(any(), any())).thenReturn(contentList);
-
-    Executable executable = () -> gitHubConnectorImpl.createBranchAndCommit("test-branch",
-        "spid", "content", "/test");
-
-    Assertions.assertThrows(RuntimeException.class, executable);
-  }
-
-  @Test
-  @SneakyThrows
   void createBranchAndCommit_errorCreatingCommit() {
 
     when(repository.getDirectoryContent(any(), any())).thenThrow(IOException.class);


### PR DESCRIPTION
Replace `delete` method with `update` in order to reduce the amount of commits needed to replace metadata files.