### PR TITLE
feat: update actions/cache to version 4.2.0 in deploy workflow

### DIFF
--- a/.github/workflows/deploy-oneid-core.yml
+++ b/.github/workflows/deploy-oneid-core.yml
@@ -80,7 +80,7 @@ jobs:
         uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
 
       - name: Cache Docker layers
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: cache
         with:
           path: build-cache-core


### PR DESCRIPTION
This **PR** updates the `actions/cache` version to 4.2.0.

Please read [this](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down) for further information.