### PR TITLE
feat: return callback uri to fe

### DIFF
--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/SAMLResponseStatusException.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/SAMLResponseStatusException.java
@@ -1,8 +1,14 @@
 package it.pagopa.oneid.exception;
 
+import lombok.Getter;
+
+@Getter
 public class SAMLResponseStatusException extends RuntimeException {
 
-  public SAMLResponseStatusException(String message) {
+  private final String redirectUri;
+
+  public SAMLResponseStatusException(String message, String redirectUri) {
     super(message);
+    this.redirectUri = redirectUri;
   }
 }

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/SAMLValidationException.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/SAMLValidationException.java
@@ -8,8 +8,12 @@ import lombok.Setter;
 public class SAMLValidationException extends RuntimeException {
 
   private final ErrorCode errorCode;
+  
   @Setter
   private String idp;
+
+  @Setter
+  private String redirectUri;
 
   public SAMLValidationException(ErrorCode errorCode) {
     super(errorCode.getErrorMessage());
@@ -20,6 +24,6 @@ public class SAMLValidationException extends RuntimeException {
     super(message);
     this.errorCode = errorCode;
   }
-  
+
 
 }

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/mapper/ExceptionMapper.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/mapper/ExceptionMapper.java
@@ -151,7 +151,8 @@ public class ExceptionMapper {
   @ServerExceptionMapper
   public RestResponse<Object> mapSAMLResponseStatusException(
       SAMLResponseStatusException samlResponseStatusException) {
-    return genericHTMLError(samlResponseStatusException.getMessage());
+    return genericHTMLError(samlResponseStatusException.getMessage(),
+        samlResponseStatusException.getRedirectUri());
   }
 
   @ServerExceptionMapper
@@ -326,6 +327,20 @@ public class ExceptionMapper {
           .location(new URI(
               BASE_PATH + "/login/error?errorCode=" + URLEncoder.encode(errorCode,
                   StandardCharsets.UTF_8))).build();
+    } catch (URISyntaxException | NullPointerException exception) {
+      return ResponseBuilder.create(INTERNAL_SERVER_ERROR).build();
+    }
+  }
+
+  private RestResponse<Object> genericHTMLError(String errorCode, String redirectUri) {
+    try {
+      return ResponseBuilder
+          .create(FOUND)
+          .location(new URI(
+              BASE_PATH + "/login/error?errorCode=" +
+                  URLEncoder.encode(errorCode, StandardCharsets.UTF_8)
+                  + "&redirectUri=" + URLEncoder.encode(redirectUri, StandardCharsets.UTF_8)))
+          .build();
     } catch (URISyntaxException | NullPointerException exception) {
       return ResponseBuilder.create(INTERNAL_SERVER_ERROR).build();
     }

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/mapper/ExceptionMapper.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/exception/mapper/ExceptionMapper.java
@@ -164,7 +164,8 @@ public class ExceptionMapper {
     cloudWatchConnectorImpl.sendIDPErrorMetricData(samlValidationException.getIdp(),
         samlValidationException.getErrorCode());
 
-    return genericHTMLError(samlValidationException.getErrorCode().getErrorCode());
+    return genericHTMLError(samlValidationException.getErrorCode().getErrorCode(),
+        samlValidationException.getRedirectUri());
   }
 
   @ServerExceptionMapper

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SAMLService.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SAMLService.java
@@ -29,6 +29,6 @@ public interface SAMLService {
 
   Optional<IDP> getIDPFromEntityID(String entityID);
 
-  void checkSAMLStatus(Response response) throws OneIdentityException;
+  void checkSAMLStatus(Response response, String redirectUri) throws OneIdentityException;
 
 }

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SAMLService.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SAMLService.java
@@ -19,7 +19,7 @@ public interface SAMLService {
       throws OneIdentityException;
 
   void validateSAMLResponse(Response SAMLResponse, String entityID, Set<String> requestedAttributes,
-      Instant samlRequestIssueInstant, AuthLevel authLevelRequest)
+      Instant samlRequestIssueInstant, AuthLevel authLevelRequest, String redirectUri)
       throws OneIdentityException;
 
   Response getSAMLResponseFromString(String SAMLResponse) throws OneIdentityException;

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SAMLServiceImpl.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SAMLServiceImpl.java
@@ -528,7 +528,7 @@ public class SAMLServiceImpl implements SAMLService {
   @Override
   public void validateSAMLResponse(Response samlResponse, String entityID,
       Set<String> requestedAttributes, Instant samlRequestIssueInstant,
-      AuthLevel authLevelRequest) {
+      AuthLevel authLevelRequest, String redirectUri) {
 
     try {
 
@@ -546,6 +546,7 @@ public class SAMLServiceImpl implements SAMLService {
       validateSignature(samlResponse, entityID);
     } catch (SAMLValidationException e) {
       e.setIdp(entityID);
+      e.setRedirectUri(redirectUri);
       throw (e);
     }
 

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SAMLServiceImpl.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SAMLServiceImpl.java
@@ -432,7 +432,7 @@ public class SAMLServiceImpl implements SAMLService {
   }
 
   @Override
-  public void checkSAMLStatus(Response response) throws OneIdentityException {
+  public void checkSAMLStatus(Response response, String redirectUri) throws OneIdentityException {
     String statusCode = "";
     String statusMessage = "";
     if (response.getStatus() != null) {
@@ -466,7 +466,7 @@ public class SAMLServiceImpl implements SAMLService {
                   + " status code");
           throw new OneIdentityException("Status message not mapped.");
         }
-        throw new SAMLResponseStatusException(message);
+        throw new SAMLResponseStatusException(message, redirectUri);
       } else {
         Log.error(
             "SAML Status message not found for " + statusCode

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/SAMLController.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/SAMLController.java
@@ -90,7 +90,8 @@ public class SAMLController {
 
     // 1c. Check status, will raise CustomException in case of error mapped to a custom html error page
     try {
-      samlServiceImpl.checkSAMLStatus(response);
+      samlServiceImpl.checkSAMLStatus(response,
+          samlSession.getAuthorizationRequestDTOExtended().getRedirectUri());
     } catch (OneIdentityException e) {
       Log.error("error during SAMLResponse status check: " + e.getMessage());
       cloudWatchConnectorImpl.sendIDPErrorMetricData(

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/SAMLController.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/SAMLController.java
@@ -104,7 +104,8 @@ public class SAMLController {
     Client client = clientsMap.get(samlSession.getAuthorizationRequestDTOExtended().getClientId());
     samlServiceImpl.validateSAMLResponse(response,
         samlSession.getAuthorizationRequestDTOExtended().getIdp(), client.getRequestedParameters(),
-        Instant.ofEpochSecond(samlSession.getCreationTime()), client.getAuthLevel());
+        Instant.ofEpochSecond(samlSession.getCreationTime()), client.getAuthLevel(),
+        samlSession.getAuthorizationRequestDTOExtended().getRedirectUri());
 
     // 3. Get Authorization Response
     AuthorizationRequest authorizationRequest = oidcServiceImpl.buildAuthorizationRequest(

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/exception/mapper/ExceptionMapperTest.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/exception/mapper/ExceptionMapperTest.java
@@ -355,6 +355,7 @@ class ExceptionMapperTest {
     Mockito.when(exceptionMock.getErrorCode()).thenReturn(ErrorCode.IDP_ERROR_ISSUER_VALUE_BLANK);
     Mockito.when(exceptionMock.getMessage())
         .thenReturn(ErrorCode.IDP_ERROR_ISSUER_VALUE_BLANK.getErrorMessage());
+    Mockito.when(exceptionMock.getRedirectUri()).thenReturn("test.com");
 
     // when
     RestResponse<Object> restResponse = exceptionMapper.mapSAMLValidationException(

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/exception/mapper/ExceptionMapperTest.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/exception/mapper/ExceptionMapperTest.java
@@ -57,6 +57,8 @@ class ExceptionMapperTest {
 
   private final String DETAIL_MESSAGE = "detail_message";
 
+  private final String DEFAULT_FALLBACK_URI = "test.com";
+
   @Inject
   ExceptionMapper exceptionMapper;
 
@@ -338,6 +340,7 @@ class ExceptionMapperTest {
     // given
     SAMLResponseStatusException exceptionMock = Mockito.mock(SAMLResponseStatusException.class);
     Mockito.when(exceptionMock.getMessage()).thenReturn(DETAIL_MESSAGE);
+    Mockito.when(exceptionMock.getRedirectUri()).thenReturn(DEFAULT_FALLBACK_URI);
     // when
     RestResponse<Object> restResponse = exceptionMapper.mapSAMLResponseStatusException(
         exceptionMock);

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/SAMLServiceImplTest.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/SAMLServiceImplTest.java
@@ -635,7 +635,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage()
         .contains(ErrorCode.IDP_ERROR_NOT_VALID_RESPONSE_ID.getErrorMessage()));
@@ -667,7 +668,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage()
         .contains(ErrorCode.IDP_ERROR_NOT_VALID_RESPONSE_ID.getErrorMessage()));
@@ -699,7 +701,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage()
         .contains(ErrorCode.IDP_ERROR_INVALID_SAML_VERSION.getErrorMessage()));
@@ -731,7 +734,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage()
         .contains(ErrorCode.IDP_ERROR_ISSUE_INSTANT_MISSING.getErrorMessage()));
@@ -763,7 +767,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage()
         .contains(ErrorCode.IDP_ERROR_ISSUE_INSTANT_MISSING.getErrorMessage()));
@@ -796,7 +801,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.plusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.plusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage()
@@ -830,7 +836,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage()
@@ -864,7 +871,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage()
         .contains(ErrorCode.IDP_ERROR_IN_RESPONSE_TO_MISSING.getErrorMessage()));
@@ -897,7 +905,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage()
         .contains(ErrorCode.IDP_ERROR_IN_RESPONSE_TO_MISSING.getErrorMessage()));
@@ -931,7 +940,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage()
         .contains(ErrorCode.IDP_ERROR_DESTINATION_NOT_FOUND.getErrorMessage()));
@@ -965,7 +975,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage()
         .contains(ErrorCode.IDP_ERROR_DESTINATION_NOT_FOUND.getErrorMessage()));
@@ -999,7 +1010,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage()
         .contains(ErrorCode.IDP_ERROR_DESTINATION_MISMATCH.getErrorMessage()));
@@ -1033,7 +1045,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage().contains(ErrorCode.IDP_ERROR_ISSUER_VALUE_BLANK.getErrorMessage()));
@@ -1067,7 +1080,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage().contains(ErrorCode.IDP_ERROR_ISSUER_NOT_FOUND.getErrorMessage()));
@@ -1101,7 +1115,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage().contains(ErrorCode.IDP_ERROR_ISSUER_MISMATCH.getErrorMessage()));
@@ -1135,7 +1150,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage()
         .contains(ErrorCode.IDP_ERROR_ISSUER_INVALID_FORMAT.getErrorMessage()));
@@ -1169,7 +1185,8 @@ public class SAMLServiceImplTest {
     // then
     assertDoesNotThrow(
         () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-            Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+            Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+            defaultFallbackUri));
 
   }
 
@@ -1202,7 +1219,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
     assertTrue(exception.getMessage().contains(IDP_ERROR_ASSERTION_NOT_FOUND.getErrorMessage()));
   }
 
@@ -1234,7 +1252,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains(IDP_ERROR_ASSERTION_ID_MISSING.getErrorMessage()));
   }
@@ -1267,7 +1286,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains(IDP_ERROR_ASSERTION_ID_MISSING.getErrorMessage()));
   }
@@ -1300,7 +1320,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage()
         .contains(ErrorCode.IDP_ERROR_INVALID_SAML_VERSION.getErrorMessage()));
@@ -1333,7 +1354,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage()
         .contains(ErrorCode.IDP_ERROR_ISSUE_INSTANT_MISSING.getErrorMessage()));
@@ -1366,7 +1388,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.plusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.plusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage()
@@ -1400,7 +1423,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage()
@@ -1434,7 +1458,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage()
@@ -1469,7 +1494,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage()
         .contains(ErrorCode.IDP_ERROR_SUBJECT_NOT_INITIALIZED.getErrorMessage()));
@@ -1503,7 +1529,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage()
         .contains(ErrorCode.IDP_ERROR_SUBJECT_NOT_INITIALIZED.getErrorMessage()));
@@ -1537,7 +1564,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains(IDP_ERROR_INVALID_NAME_QUALIFIER.getErrorMessage()));
   }
@@ -1570,7 +1598,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage().contains(IDP_ERROR_SUBJECT_NOT_INITIALIZED.getErrorMessage()));
@@ -1604,7 +1633,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains(IDP_ERROR_INVALID_NAME_ID_TYPE.getErrorMessage()));
   }
@@ -1637,7 +1667,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains(IDP_ERROR_INVALID_NAME_ID_TYPE.getErrorMessage()));
   }
@@ -1670,7 +1701,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains(IDP_ERROR_INVALID_NAME_ID_FORMAT.getErrorMessage()));
   }
@@ -1703,7 +1735,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains(IDP_ERROR_INVALID_NAME_QUALIFIER.getErrorMessage()));
   }
@@ -1736,7 +1769,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains(IDP_ERROR_INVALID_NAME_QUALIFIER.getErrorMessage()));
   }
@@ -1769,7 +1803,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage()
         .contains(IDP_ERROR_SUBJECT_CONFIRMATION_DATA_NOT_FOUND.getErrorMessage()));
@@ -1802,7 +1837,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage()
         .contains(IDP_ERROR_SUBJECT_CONFIRMATION_NOT_INITIALIZED.getErrorMessage()));
@@ -1835,7 +1871,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage()
         .contains(IDP_ERROR_SUBJECT_CONFIRMATION_INVALID_METHOD_ATTRIBUTE.getErrorMessage()));
@@ -1869,7 +1906,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage()
         .contains(IDP_ERROR_SUBJECT_CONFIRMATION_INVALID_METHOD_ATTRIBUTE.getErrorMessage()));
@@ -1903,7 +1941,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage()
         .contains(IDP_ERROR_SUBJECT_CONFIRMATION_INVALID_METHOD_ATTRIBUTE.getErrorMessage()));
@@ -1937,7 +1976,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage()
         .contains(IDP_ERROR_SUBJECT_CONFIRMATION_DATA_NOT_FOUND.getErrorMessage()));
@@ -1971,7 +2011,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage().contains(ErrorCode.IDP_ERROR_RECIPIENT_NOT_FOUND.getErrorMessage()));
@@ -2005,7 +2046,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage().contains(ErrorCode.IDP_ERROR_RECIPIENT_NOT_FOUND.getErrorMessage()));
@@ -2039,7 +2081,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains(IDP_ERROR_RECIPIENT_MISMATCH.getErrorMessage()));
   }
@@ -2072,7 +2115,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains(IDP_ERROR_IN_RESPONSE_TO_MISSING.getErrorMessage()));
   }
@@ -2105,7 +2149,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains(IDP_ERROR_IN_RESPONSE_TO_MISSING.getErrorMessage()));
   }
@@ -2138,7 +2183,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage().contains(IDP_ERROR_NOT_ON_OR_AFTER_NOT_FOUND.getErrorMessage()));
@@ -2172,7 +2218,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage().contains(IDP_ERROR_NOT_ON_OR_AFTER_NOT_FOUND.getErrorMessage()));
@@ -2206,7 +2253,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage().contains(IDP_ERROR_NOT_ON_OR_AFTER_EXPIRED.getErrorMessage()));
@@ -2240,7 +2288,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains(IDP_ERROR_ISSUER_VALUE_BLANK.getErrorMessage()));
   }
@@ -2273,7 +2322,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains(IDP_ERROR_ISSUER_NOT_FOUND.getErrorMessage()));
   }
@@ -2306,7 +2356,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains(IDP_ERROR_ISSUER_MISMATCH.getErrorMessage()));
   }
@@ -2339,7 +2390,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains(IDP_ERROR_ISSUER_INVALID_FORMAT.getErrorMessage()));
   }
@@ -2372,7 +2424,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains(IDP_ERROR_ISSUER_INVALID_FORMAT.getErrorMessage()));
   }
@@ -2405,7 +2458,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains(IDP_ERROR_ISSUER_INVALID_FORMAT.getErrorMessage()));
   }
@@ -2438,7 +2492,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage()
@@ -2473,7 +2528,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage().contains(IDP_ERROR_MISSING_CONDITIONS.getErrorMessage()));
@@ -2506,7 +2562,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage().contains(IDP_ERROR_NOT_BEFORE_NOT_FOUND.getErrorMessage()));
@@ -2539,7 +2596,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage().contains(IDP_ERROR_NOT_BEFORE_NOT_FOUND.getErrorMessage()));
@@ -2572,7 +2630,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage().contains(IDP_ERROR_NOT_BEFORE_IN_THE_FUTURE.getErrorMessage()));
@@ -2605,7 +2664,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage().contains(IDP_ERROR_NOT_ON_OR_AFTER_NOT_FOUND.getErrorMessage()));
@@ -2638,7 +2698,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage().contains(IDP_ERROR_NOT_ON_OR_AFTER_NOT_FOUND.getErrorMessage()));
@@ -2671,7 +2732,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage().contains(IDP_ERROR_NOT_ON_OR_AFTER_EXPIRED.getErrorMessage()));
@@ -2704,7 +2766,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage()
@@ -2738,7 +2801,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage()
@@ -2772,7 +2836,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage().contains(IDP_ERROR_AUDIENCE_MISMATCH.getErrorMessage()));
@@ -2805,7 +2870,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage()
@@ -2839,7 +2905,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage().contains(IDP_ERROR_AUDIENCE_MISMATCH.getErrorMessage()));
@@ -2872,7 +2939,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage().contains(IDP_ERROR_AUTHN_CONTEXT_MISSING.getErrorMessage()));
@@ -2905,7 +2973,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage()
@@ -2939,7 +3008,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage()
@@ -2973,7 +3043,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage().contains(IDP_ERROR_AUTHN_CONTEXT_MISSING.getErrorMessage()));
@@ -3006,7 +3077,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage()
@@ -3040,7 +3112,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage()
@@ -3073,7 +3146,8 @@ public class SAMLServiceImplTest {
     // then
     assertDoesNotThrow(
         () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-            Set.of("fiscalNumber", "spidCode"), mockInstant.minusSeconds(10), AuthLevel.L1));
+            Set.of("fiscalNumber", "spidCode"), mockInstant.minusSeconds(10), AuthLevel.L1,
+            defaultFallbackUri));
   }
 
   @Test
@@ -3103,7 +3177,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage()
@@ -3138,7 +3213,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L3));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L3,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage()
@@ -3173,7 +3249,8 @@ public class SAMLServiceImplTest {
     // then
     assertDoesNotThrow(
         () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-            Set.of("fiscalNumber", "spidCode"), mockInstant.minusSeconds(10), AuthLevel.L1));
+            Set.of("fiscalNumber", "spidCode"), mockInstant.minusSeconds(10), AuthLevel.L1,
+            defaultFallbackUri));
   }
 
   @Test
@@ -3202,7 +3279,8 @@ public class SAMLServiceImplTest {
     // then
     assertDoesNotThrow(
         () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-            Set.of("fiscalNumber", "spidCode"), mockInstant.minusSeconds(10), AuthLevel.L2));
+            Set.of("fiscalNumber", "spidCode"), mockInstant.minusSeconds(10), AuthLevel.L2,
+            defaultFallbackUri));
   }
 
   @Test
@@ -3232,7 +3310,8 @@ public class SAMLServiceImplTest {
     SAMLValidationException exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L3));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L3,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getErrorCode().getErrorMessage()
@@ -3266,7 +3345,8 @@ public class SAMLServiceImplTest {
     // then
     assertDoesNotThrow(
         () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-            Set.of("fiscalNumber", "spidCode"), mockInstant.minusSeconds(10), AuthLevel.L1));
+            Set.of("fiscalNumber", "spidCode"), mockInstant.minusSeconds(10), AuthLevel.L1,
+            defaultFallbackUri));
   }
 
   @Test
@@ -3295,7 +3375,8 @@ public class SAMLServiceImplTest {
     // then
     assertDoesNotThrow(
         () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-            Set.of("fiscalNumber", "spidCode"), mockInstant.minusSeconds(10), AuthLevel.L2));
+            Set.of("fiscalNumber", "spidCode"), mockInstant.minusSeconds(10), AuthLevel.L2,
+            defaultFallbackUri));
   }
 
   @Test
@@ -3324,7 +3405,8 @@ public class SAMLServiceImplTest {
     // then
     assertDoesNotThrow(
         () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-            Set.of("fiscalNumber", "spidCode"), mockInstant.minusSeconds(10), AuthLevel.L3));
+            Set.of("fiscalNumber", "spidCode"), mockInstant.minusSeconds(10), AuthLevel.L3,
+            defaultFallbackUri));
   }
 
   @Test
@@ -3353,7 +3435,8 @@ public class SAMLServiceImplTest {
     // then
     assertDoesNotThrow(
         () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-            Set.of("fiscalNumber", "spidCode"), mockInstant.minusSeconds(10), AuthLevel.L2));
+            Set.of("fiscalNumber", "spidCode"), mockInstant.minusSeconds(10), AuthLevel.L2,
+            defaultFallbackUri));
   }
 
   @Test
@@ -3383,7 +3466,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage()
@@ -3417,7 +3501,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage().contains(IDP_ERROR_ATTRIBUTES_NOT_PRESENT.getErrorMessage()));
@@ -3450,7 +3535,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage()
@@ -3484,7 +3570,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage().contains(IDP_ERROR_ATTRIBUTES_NOT_MATCHING.getErrorMessage()));
@@ -3516,7 +3603,8 @@ public class SAMLServiceImplTest {
     // then
     assertDoesNotThrow(
         () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-            Set.of("fiscalNumber", "spidCode"), mockInstant.minusSeconds(10), AuthLevel.L2));
+            Set.of("fiscalNumber", "spidCode"), mockInstant.minusSeconds(10), AuthLevel.L2,
+            defaultFallbackUri));
 
   }
 
@@ -3546,7 +3634,8 @@ public class SAMLServiceImplTest {
     // then
     assertDoesNotThrow(
         () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-            Set.of("fiscalNumber", "spidCode"), mockInstant.minusSeconds(10), AuthLevel.L2));
+            Set.of("fiscalNumber", "spidCode"), mockInstant.minusSeconds(10), AuthLevel.L2,
+            defaultFallbackUri));
   }
 
   //CIE
@@ -3580,7 +3669,7 @@ public class SAMLServiceImplTest {
     assertDoesNotThrow(
         () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
             Set.of("spidCode", "fiscalNumber"), // requested
-            mockInstant.minusSeconds(10), AuthLevel.L2));
+            mockInstant.minusSeconds(10), AuthLevel.L2, defaultFallbackUri));
   }
 
   @Test
@@ -3614,7 +3703,7 @@ public class SAMLServiceImplTest {
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
                 Set.of("fiscalNumber", "familyName", "dateOfBirth"), // requested
-                mockInstant.minusSeconds(10), AuthLevel.L2));
+                mockInstant.minusSeconds(10), AuthLevel.L2, defaultFallbackUri));
 
     assertTrue(
         exception.getMessage()
@@ -3652,7 +3741,7 @@ public class SAMLServiceImplTest {
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
                 Set.of("fiscalNumber", "familyName", "dateOfBirth"), // requested
-                mockInstant.minusSeconds(10), AuthLevel.L2));
+                mockInstant.minusSeconds(10), AuthLevel.L2, defaultFallbackUri));
 
     assertTrue(
         exception.getMessage()
@@ -3691,7 +3780,7 @@ public class SAMLServiceImplTest {
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
                 Set.of("fiscalNumber", "familyName", "dateOfBirth"),
                 // requested
-                mockInstant.minusSeconds(10), AuthLevel.L2));
+                mockInstant.minusSeconds(10), AuthLevel.L2, defaultFallbackUri));
 
     assertTrue(
         exception.getMessage()
@@ -3731,7 +3820,7 @@ public class SAMLServiceImplTest {
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
                 Set.of("fiscalNumber", "familyName", "dateOfBirth"),
                 // requested
-                mockInstant.minusSeconds(10), AuthLevel.L2));
+                mockInstant.minusSeconds(10), AuthLevel.L2, defaultFallbackUri));
 
     assertTrue(
         exception.getMessage()
@@ -3770,7 +3859,7 @@ public class SAMLServiceImplTest {
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
                 Set.of("fiscalNumber", "familyName", "dateOfBirth"),
                 // requested
-                mockInstant.minusSeconds(10), AuthLevel.L2));
+                mockInstant.minusSeconds(10), AuthLevel.L2, defaultFallbackUri));
 
     assertTrue(
         exception.getMessage()
@@ -3806,7 +3895,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
     assertTrue(exception.getMessage().contains(IDP_ERROR_MULTIPLE_ASSERTIONS.getErrorMessage()));
   }
 
@@ -3837,7 +3927,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
     assertTrue(exception.getMessage()
         .contains(IDP_ERROR_MULTIPLE_SUBJECT_CONFIRMATIONS.getErrorMessage()));
   }
@@ -3871,7 +3962,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage()
@@ -3905,7 +3997,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage().contains(IDP_ERROR_MULTIPLE_AUDIENCES.getErrorMessage()));
@@ -3939,7 +4032,8 @@ public class SAMLServiceImplTest {
     Exception exception =
         assertThrows(SAMLValidationException.class,
             () -> samlServiceImpl.validateSAMLResponse(response, testIDP.getEntityID(),
-                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2));
+                Set.of("fiscalNumber", "dateOfBirth"), mockInstant.minusSeconds(10), AuthLevel.L2,
+                defaultFallbackUri));
 
     assertTrue(
         exception.getMessage().contains(IDP_ERROR_MULTIPLE_ATTRIBUTE_STATEMENTS.getErrorMessage()));

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/SAMLServiceImplTest.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/SAMLServiceImplTest.java
@@ -205,24 +205,19 @@ import org.slf4j.LoggerFactory;
 public class SAMLServiceImplTest {
 
   private static final Logger log = LoggerFactory.getLogger(SAMLServiceImplTest.class);
+  private final String defaultFallbackUri = "test.com";
   @ConfigProperty(name = "timestamp_spid")
   String TIMESTAMP_SPID;
-
   @ConfigProperty(name = "timestamp_cie")
   String TIMESTAMP_CIE;
-
   @ConfigProperty(name = "cie_entity_id")
   String CIE_ENTITY_ID;
-
   @Inject
   SAMLServiceImpl samlServiceImpl;
-
   @InjectSpy
   SAMLUtilsExtendedCore samlUtils;
-
   @InjectMock
   IDPConnectorImpl idpConnectorImpl;
-
   @InjectSpy
   Clock clock;
 
@@ -309,7 +304,7 @@ public class SAMLServiceImplTest {
     when(status.getStatusCode()).thenReturn(statusCode);
     when(response.getStatus()).thenReturn(status);
     // then
-    assertDoesNotThrow(() -> samlServiceImpl.checkSAMLStatus(response));
+    assertDoesNotThrow(() -> samlServiceImpl.checkSAMLStatus(response, defaultFallbackUri));
   }
 
   @Test
@@ -321,7 +316,8 @@ public class SAMLServiceImplTest {
     when(status.getStatusCode()).thenReturn(null);
     when(response.getStatus()).thenReturn(status);
     // then
-    assertThrows(OneIdentityException.class, () -> samlServiceImpl.checkSAMLStatus(response));
+    assertThrows(OneIdentityException.class,
+        () -> samlServiceImpl.checkSAMLStatus(response, defaultFallbackUri));
   }
 
   @Test
@@ -339,7 +335,7 @@ public class SAMLServiceImplTest {
     when(response.getStatus()).thenReturn(status);
     // then
     assertThrows(SAMLResponseStatusException.class,
-        () -> samlServiceImpl.checkSAMLStatus(response));
+        () -> samlServiceImpl.checkSAMLStatus(response, defaultFallbackUri));
   }
 
   @Test
@@ -357,7 +353,7 @@ public class SAMLServiceImplTest {
     when(response.getStatus()).thenReturn(status);
     // then
     assertThrows(OneIdentityException.class,
-        () -> samlServiceImpl.checkSAMLStatus(response));
+        () -> samlServiceImpl.checkSAMLStatus(response, defaultFallbackUri));
   }
 
   @Test
@@ -367,7 +363,7 @@ public class SAMLServiceImplTest {
     Response response = samlUtils.getSAMLResponseFromString(NOT_SPECIFIED_STATUS_SAML_RESPONSE_22);
     // then
     Exception exception = assertThrows(OneIdentityException.class,
-        () -> samlServiceImpl.checkSAMLStatus(response));
+        () -> samlServiceImpl.checkSAMLStatus(response, defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains("Status Code not set."));
   }
@@ -379,7 +375,7 @@ public class SAMLServiceImplTest {
     Response response = samlUtils.getSAMLResponseFromString(MISSING_STATUS_SAML_RESPONSE_23);
     // then
     Exception exception = assertThrows(OneIdentityException.class,
-        () -> samlServiceImpl.checkSAMLStatus(response));
+        () -> samlServiceImpl.checkSAMLStatus(response, defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains("Status message not set."));
   }
@@ -392,7 +388,7 @@ public class SAMLServiceImplTest {
         NOT_SPECIFIED_STATUS_CODE_SAML_RESPONSE_24);
     // then
     Exception exception = assertThrows(OneIdentityException.class,
-        () -> samlServiceImpl.checkSAMLStatus(response));
+        () -> samlServiceImpl.checkSAMLStatus(response, defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains("Status Code not set."));
   }
@@ -405,7 +401,7 @@ public class SAMLServiceImplTest {
         MISSING_STATUS_CODE_SAML_RESPONSE_25);
     // then
     Exception exception = assertThrows(OneIdentityException.class,
-        () -> samlServiceImpl.checkSAMLStatus(response));
+        () -> samlServiceImpl.checkSAMLStatus(response, defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains("Status Code not set."));
   }
@@ -418,7 +414,7 @@ public class SAMLServiceImplTest {
         STATUS_CODE_DIFFERENT_FROM_SUCCESS_SAML_RESPONSE_26);
     // then
     Exception exception = assertThrows(OneIdentityException.class,
-        () -> samlServiceImpl.checkSAMLStatus(response));
+        () -> samlServiceImpl.checkSAMLStatus(response, defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains("Status message not set."));
   }
@@ -431,7 +427,7 @@ public class SAMLServiceImplTest {
         REPEATED_WRONG_CREDENTIALS_SUBMITTED_SAML_RESPONSE_104);
     // then
     Exception exception = assertThrows(SAMLResponseStatusException.class,
-        () -> samlServiceImpl.checkSAMLStatus(response));
+        () -> samlServiceImpl.checkSAMLStatus(response, defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains(ERRORCODE_NR19.getErrorCode()));
   }
@@ -444,7 +440,7 @@ public class SAMLServiceImplTest {
         USER_WITHOUT_COMPATIBLE_CREDENTIALS_SAML_RESPONSE_105);
     // then
     Exception exception = assertThrows(SAMLResponseStatusException.class,
-        () -> samlServiceImpl.checkSAMLStatus(response));
+        () -> samlServiceImpl.checkSAMLStatus(response, defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains(ERRORCODE_NR20.getErrorCode()));
   }
@@ -457,7 +453,7 @@ public class SAMLServiceImplTest {
         TIMEOUT_SAML_RESPONSE_106);
     // then
     Exception exception = assertThrows(SAMLResponseStatusException.class,
-        () -> samlServiceImpl.checkSAMLStatus(response));
+        () -> samlServiceImpl.checkSAMLStatus(response, defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains(ERRORCODE_NR21.getErrorCode()));
   }
@@ -470,7 +466,7 @@ public class SAMLServiceImplTest {
         CONSENT_NEGATED_SAML_RESPONSE_107);
     // then
     Exception exception = assertThrows(SAMLResponseStatusException.class,
-        () -> samlServiceImpl.checkSAMLStatus(response));
+        () -> samlServiceImpl.checkSAMLStatus(response, defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains(ERRORCODE_NR22.getErrorCode()));
   }
@@ -483,7 +479,7 @@ public class SAMLServiceImplTest {
         BLOCKED_CREDENTIALS_SAML_RESPONSE_108);
     // then
     Exception exception = assertThrows(SAMLResponseStatusException.class,
-        () -> samlServiceImpl.checkSAMLStatus(response));
+        () -> samlServiceImpl.checkSAMLStatus(response, defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains(ERRORCODE_NR23.getErrorCode()));
   }
@@ -497,7 +493,7 @@ public class SAMLServiceImplTest {
     );
     // then
     Exception exception = assertThrows(SAMLResponseStatusException.class,
-        () -> samlServiceImpl.checkSAMLStatus(response));
+        () -> samlServiceImpl.checkSAMLStatus(response, defaultFallbackUri));
 
     assertTrue(exception.getMessage().contains(ERRORCODE_NR25.getErrorCode()));
   }

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/web/controller/SAMLControllerTest.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/web/controller/SAMLControllerTest.java
@@ -77,7 +77,7 @@ public class SAMLControllerTest {
     doNothing().when(samlServiceImpl).checkSAMLStatus(Mockito.any(), Mockito.any());
     doNothing().when(samlServiceImpl)
         .validateSAMLResponse(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
-            Mockito.any());
+            Mockito.any(), Mockito.any());
 
     // setup oidcServiceImpl mock
     AuthorizationRequest authorizationRequest = Mockito.mock(AuthorizationRequest.class);
@@ -250,18 +250,27 @@ public class SAMLControllerTest {
     // setup samlServiceImplMock
 
     Response response = Mockito.mock(Response.class);
+    SAMLValidationException samlValidationException = Mockito.mock(SAMLValidationException.class);
+    Mockito.when(samlValidationException.getRedirectUri()).thenReturn("test.com");
+    Mockito.when(samlValidationException.getMessage())
+        .thenReturn(ErrorCode.IDP_ERROR_INVALID_SAML_VERSION.getErrorMessage());
+    Mockito.when(samlValidationException.getErrorCode())
+        .thenReturn(ErrorCode.IDP_ERROR_INVALID_SAML_VERSION);
+
     Mockito.when(response.getInResponseTo()).thenReturn("dummyInResponseTo");
     Mockito.when(samlServiceImpl.getSAMLResponseFromString(Mockito.any())).thenReturn(response);
 
     doNothing().when(samlServiceImpl).checkSAMLStatus(Mockito.any(), Mockito.any());
-    doThrow(new SAMLValidationException(ErrorCode.IDP_ERROR_INVALID_SAML_VERSION)).when(
+    samlValidationException.setRedirectUri("test.com");
+    doThrow(samlValidationException).when(
             samlServiceImpl)
         .validateSAMLResponse(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
-            Mockito.any());
+            Mockito.any(), Mockito.any());
     // location header to verify
-    String headerLocation = BASE_PATH + "/login/error?errorCode=" + URLEncoder.encode(
-        ErrorCode.IDP_ERROR_INVALID_SAML_VERSION.getErrorCode(),
-        StandardCharsets.UTF_8);
+    String headerLocation = BASE_PATH + "/login/error?errorCode=" +
+        URLEncoder.encode(ErrorCode.IDP_ERROR_INVALID_SAML_VERSION.getErrorCode(),
+            StandardCharsets.UTF_8) +
+        "&redirectUri=" + URLEncoder.encode("test.com", StandardCharsets.UTF_8);
     String location = given()
         .formParams(samlResponseDTO)
         .when()
@@ -291,7 +300,7 @@ public class SAMLControllerTest {
     doNothing().when(samlServiceImpl).checkSAMLStatus(Mockito.any(), Mockito.any());
     doNothing().when(samlServiceImpl)
         .validateSAMLResponse(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
-            Mockito.any());
+            Mockito.any(), Mockito.any());
 
     // setup oidcServiceImpl mock
     AuthorizationRequest authorizationRequest = Mockito.mock(AuthorizationRequest.class);
@@ -350,7 +359,7 @@ public class SAMLControllerTest {
     doNothing().when(samlServiceImpl).checkSAMLStatus(Mockito.any(), Mockito.any());
     doNothing().when(samlServiceImpl)
         .validateSAMLResponse(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
-            Mockito.any());
+            Mockito.any(), Mockito.any());
 
     // setup oidcServiceImpl mock
     AuthorizationRequest authorizationRequest = Mockito.mock(AuthorizationRequest.class);

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/web/controller/SAMLControllerTest.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/web/controller/SAMLControllerTest.java
@@ -74,7 +74,7 @@ public class SAMLControllerTest {
     Mockito.when(response.getInResponseTo()).thenReturn("Dummy");
     Mockito.when(samlServiceImpl.getSAMLResponseFromString(Mockito.any())).thenReturn(response);
 
-    doNothing().when(samlServiceImpl).checkSAMLStatus(Mockito.any());
+    doNothing().when(samlServiceImpl).checkSAMLStatus(Mockito.any(), Mockito.any());
     doNothing().when(samlServiceImpl)
         .validateSAMLResponse(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
             Mockito.any());
@@ -220,7 +220,8 @@ public class SAMLControllerTest {
     Mockito.when(response.getInResponseTo()).thenReturn("dummyInResponseTo");
     Mockito.when(samlServiceImpl.getSAMLResponseFromString(Mockito.any())).thenReturn(response);
 
-    doThrow(new OneIdentityException()).when(samlServiceImpl).checkSAMLStatus(Mockito.any());
+    doThrow(new OneIdentityException()).when(samlServiceImpl)
+        .checkSAMLStatus(Mockito.any(), Mockito.any());
 
     // location header to verify
     String headerLocation = BASE_PATH + "/login/error?errorCode=" + URLEncoder.encode(
@@ -252,7 +253,7 @@ public class SAMLControllerTest {
     Mockito.when(response.getInResponseTo()).thenReturn("dummyInResponseTo");
     Mockito.when(samlServiceImpl.getSAMLResponseFromString(Mockito.any())).thenReturn(response);
 
-    doNothing().when(samlServiceImpl).checkSAMLStatus(Mockito.any());
+    doNothing().when(samlServiceImpl).checkSAMLStatus(Mockito.any(), Mockito.any());
     doThrow(new SAMLValidationException(ErrorCode.IDP_ERROR_INVALID_SAML_VERSION)).when(
             samlServiceImpl)
         .validateSAMLResponse(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
@@ -287,7 +288,7 @@ public class SAMLControllerTest {
     Mockito.when(response.getInResponseTo()).thenReturn("exceptionOIDC");
     Mockito.when(samlServiceImpl.getSAMLResponseFromString(Mockito.any())).thenReturn(response);
 
-    doNothing().when(samlServiceImpl).checkSAMLStatus(Mockito.any());
+    doNothing().when(samlServiceImpl).checkSAMLStatus(Mockito.any(), Mockito.any());
     doNothing().when(samlServiceImpl)
         .validateSAMLResponse(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
             Mockito.any());
@@ -346,7 +347,7 @@ public class SAMLControllerTest {
     Mockito.when(response.getInResponseTo()).thenReturn("dummyInResponseTo");
     Mockito.when(samlServiceImpl.getSAMLResponseFromString(Mockito.any())).thenReturn(response);
 
-    doNothing().when(samlServiceImpl).checkSAMLStatus(Mockito.any());
+    doNothing().when(samlServiceImpl).checkSAMLStatus(Mockito.any(), Mockito.any());
     doNothing().when(samlServiceImpl)
         .validateSAMLResponse(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
             Mockito.any());


### PR DESCRIPTION
This **PR** adds `redirectUri` query parameter when redirecting to the `/login/error?` page allowing the FE to correctly redirect the user to the Product callback with a specific error.