### PR TITLE
fix: lambda update status permission

### DIFF
--- a/src/infra/modules/backend/lambda.tf
+++ b/src/infra/modules/backend/lambda.tf
@@ -598,7 +598,7 @@ resource "aws_cloudwatch_metric_alarm" "dlq_assertions" {
 }
 
 
-## Lambda update IDP status
+## Lambda update IDP and Client status
 
 data "aws_iam_policy_document" "update_status_lambda" {
   statement {
@@ -675,11 +675,11 @@ module "update_status_lambda" {
   allowed_triggers = {
     IDPErrorRate = {
       principal  = "lambda.alarms.cloudwatch.amazonaws.com"
-      source_arn = "arn:aws:cloudwatch:${var.aws_region}:${var.account_id}:alarm:IDPErrorRateAlarm-*"
+      source_arn = "arn:aws:cloudwatch:${var.aws_region}:${var.account_id}:alarm:IDPErrorRateAlarm*"
     },
     ClientErrorRate = {
       principal  = "lambda.alarms.cloudwatch.amazonaws.com"
-      source_arn = "arn:aws:cloudwatch:${var.aws_region}:${var.account_id}:alarm:ClientErrorRateAlarm-*"
+      source_arn = "arn:aws:cloudwatch:${var.aws_region}:${var.account_id}:alarm:ClientErrorRateAlarm*"
     }
   }
 

--- a/src/oneid/oneid-lambda-update-status/lambda.py
+++ b/src/oneid/oneid-lambda-update-status/lambda.py
@@ -56,12 +56,16 @@ def get_event_data(event):
     Extract the event data from event
     """
     # Extract the event data considering that it is a CloudWatch alarm event
-    # The alarm name is in the format {ALARM_TYPE}-{KEY}
+    # The alarm name is in the format {ALARM_TYPE}_{ENV_SHORT}_{KEY}
     # ALARM_TYPE is one of the following: IDPErrorRateAlarm, ClientErrorRateAlarm
-    # whilst KEY is one of the CLIENT/IDP ids
+    # whilst KEY is "entityId" if Alarm Type is "IDPErrorRateAlarm" or "FriendlyName_ClientId" if Alarm Type is "ClientErrorRateAlarm"
     alarm_data = event["alarmData"]
     alarm_name = alarm_data["alarmName"]
-    alarm_type, key = alarm_name.split("-", 1)
+    alarm_type, env_short, key = alarm_name.split("_", 2)
+    if alarm_type == "ClientErrorRateAlarm":
+        # Extract the client ID from the alarm name
+        # The client ID is the last 43 characters of the alarm name
+        key = key[-43:]
     alarm_state = alarm_data["state"]["value"]
 
     return alarm_type, key, alarm_state


### PR DESCRIPTION
This **PR** updates `lambda-update-status` infra and code to be compliant with the new CloudWatch custom alarm naming convention 