### PR TITLE
chore: add error log when retrieving empty session by authorization code

### DIFF
--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/interceptors/ControllerInterceptor.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/interceptors/ControllerInterceptor.java
@@ -110,6 +110,7 @@ public class ControllerInterceptor {
     try {
       session = samlSessionServiceImpl.getSAMLSessionByCode(tokenRequestDTOExtended.getCode());
     } catch (SessionException e) {
+      Log.error("authorization code not found or expired");
       throw new InvalidGrantException(clientId);
     }
 


### PR DESCRIPTION
This **PR**  adds an error log when retrieving empty session by authorization code.

This message will help us identifying such cases in order to improve debugging.