### PR TITLE
feat: add retry on GSI idx when retrieving OIDC Session

### DIFF
--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/CloudWatchConnector.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/CloudWatchConnector.java
@@ -12,6 +12,8 @@ public interface CloudWatchConnector {
 
   void sendClientErrorMetricData(String clientID, ErrorCode errorCode);
 
+  void sendOIDynamoDBErrorMetricData(int numAttempts);
+
   void sendClientSuccessMetricData(String ClientID);
 
 }

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/CloudWatchConnectorImpl.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/CloudWatchConnectorImpl.java
@@ -17,6 +17,7 @@ import software.amazon.awssdk.services.cloudwatch.model.PutMetricDataRequest;
 public class CloudWatchConnectorImpl implements CloudWatchConnector {
 
   private final String tagIDP = "IDP";
+  private final String tagDynamoDB = "DynamoDBAttempts";
   private final String tagSAMLStatus = "SAMLStatus";
   private final String tagClient = "Client";
   private final String tagAggregated = "Aggregated";
@@ -101,6 +102,18 @@ public class CloudWatchConnectorImpl implements CloudWatchConnector {
 
     cloudWatchAsyncClient.putMetricData(
         generatePutMetricRequest(tagIDP + tagSuccess, dimensions));
+  }
+
+  @Override
+  public void sendOIDynamoDBErrorMetricData(int numAttempts) {
+
+    List<Dimension> dimensions = List.of(Dimension.builder()
+        .name(tagDynamoDB)
+        .value(String.valueOf(numAttempts))
+        .build());
+
+    cloudWatchAsyncClient.putMetricData(
+        generatePutMetricRequest(tagDynamoDB, dimensions));
   }
 
   @Override


### PR DESCRIPTION
This **PR** adds retry during OIDC Session retrieving to bypass the eventually read consistency when reading from GSI in DynamoDB.

With this enhancement we want to reduce the `INVALID_GRANT` errors which appears during `/token` endpoint invocations.