### PR TITLE
Feat: add route to client manager

### DIFF
--- a/src/infra/api/oi-admin.tpl.json
+++ b/src/infra/api/oi-admin.tpl.json
@@ -116,7 +116,7 @@
         "tags": [
           "Admin Client Manager APIs"
         ],
-        "description": "This endpoint updates optional fields on Client related table",
+        "description": "This endpoint updates optional fields of a Client",
         "operationId": "Put_admin_client_manager_client_additional",
         "parameters": [
           {
@@ -184,6 +184,94 @@
         "responses": {
           "204": {
             "$ref": "#/components/responses/responseOkNoContentJson"
+          },
+          "400": {
+            "$ref": "#/components/responses/invalidParameters"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "405": {
+            "$ref": "#/components/responses/methodNotAllowed"
+          },
+          "429": {
+            "$ref": "#/components/responses/rateLimit"
+          },
+          "500": {
+            "$ref": "#/components/responses/serverError"
+          }
+        },
+        "security": [
+          {
+            "${authorizer}": []
+          }
+        ]
+      },
+
+      "get": {
+        "tags": [
+          "Admin Client Manager APIs"
+        ],
+        "description": "This endpoint retrieves optional fields of a Client",
+        "operationId": "Get_admin_client_manager_client_additional",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "client_id",
+            "description": "client_id that was returned in the client registration response",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "x-amazon-apigateway-integration": {
+          "credentials": "${lambda_apigateway_proxy_role}",
+          "passthroughBehavior": "when_no_match",
+          "contentHandling": "CONVERT_TO_TEXT",
+          "type": "aws_proxy",
+          "httpMethod": "POST",
+          "uri": "arn:aws:apigateway:${aws_region}:lambda:path/2015-03-31/functions/${client_manager_lambda_arn}/invocations",
+          "responses": {
+            "200": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.content-type": "'application/json'"
+              }
+            },
+            "400": {
+              "statusCode": "400",
+              "responseParameters": {}
+            },
+            "401": {
+              "statusCode": "401",
+              "responseParameters": {}
+            },
+            "403": {
+              "statusCode": "403",
+              "responseParameters": {}
+            },
+            "405": {
+              "statusCode": "405",
+              "responseParameters": {}
+            },
+            "429": {
+              "statusCode": "405",
+              "responseParameters": {}
+            },
+            "500": {
+              "statusCode": "500",
+              "responseParameters": {}
+            }
+          }
+        },
+        "summary": "Client Onboarding portal backend",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/responseOkClientAdditionalJson"
           },
           "400": {
             "$ref": "#/components/responses/invalidParameters"
@@ -907,8 +995,27 @@
           }
         }
       },
-      "responseOkUsersJson": {
+      "responseOkClientAdditionalJson":{
         "description": "Response Ok, No Content",
+        "headers": {
+          "content-type": {
+            "application/json": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ClientAdditional"
+            }
+          }
+        }
+      },
+      "responseOkUsersJson": {
+        "description": "Users list",
         "headers": {
           "content-type": {
             "application/json": {

--- a/src/infra/api/oi-admin.tpl.json
+++ b/src/infra/api/oi-admin.tpl.json
@@ -27,7 +27,7 @@
     "/client-manager/user-attributes": {
       "put": {
         "tags": ["Admin Client Manager APIs"],
-        "description": "This endpoint expose backend function for Client Onboarding Portal.",
+        "description": "This endpoint updates the Cognito user attributes by inserting the client_id value.",
         "operationId": "Put_admin_client_manager_user_attributes",
         "x-amazon-apigateway-integration": {
           "credentials": "${lambda_apigateway_proxy_role}",
@@ -116,7 +116,7 @@
         "tags": [
           "Admin Client Manager APIs"
         ],
-        "description": "This endpoint expose backend function for Client Onboarding Portal.",
+        "description": "This endpoint updates optional fields on Client related table",
         "operationId": "Put_admin_client_manager_client_additional",
         "parameters": [
           {
@@ -218,7 +218,7 @@
         "tags": [
           "Admin Client Manager APIs"
         ],
-        "description": "This endpoint expose backend function for Client Onboarding Portal.",
+        "description": "This endpoint creates a user in the Internal IDP",
         "operationId": "Post_admin_client_manager_client_users",
         "x-amazon-apigateway-integration": {
           "credentials": "${lambda_apigateway_proxy_role}",
@@ -320,7 +320,7 @@
         "tags": [
           "Admin Client Manager APIs"
         ],
-        "description": "This endpoint expose backend function for Client Onboarding Portal.",
+        "description": "This endpoint updates a user in the Internal IDP",
         "operationId": "Put_admin_client_manager_client_users",
         "parameters": [
           {
@@ -427,7 +427,7 @@
         "tags": [
           "Admin Client Manager APIs"
         ],
-        "description": "This endpoint expose backend function for Client Onboarding Portal.",
+        "description": "This endpoint deletes a user in the Internal IDP",
         "operationId": "Delete_admin_client_manager_client_users",
         "parameters": [
           {
@@ -1206,11 +1206,11 @@
         "properties": {
           "user_id": {
             "type": "string",
-            "description": "The user id"
+            "description": "Cognito username of the user"
           },
           "client_id": {
             "type": "string",
-            "description": "The client id"
+            "description": "Client ID to associate to the user"
           }
         }
       },

--- a/src/oneid/oneid-lambda-client-manager/index.py
+++ b/src/oneid/oneid-lambda-client-manager/index.py
@@ -237,7 +237,7 @@ def get_optional_attributes(client_id: str):
 
 
 @app.put("/client-manager/client-additional/<client_id>")
-def update_optional_attributes(client_id):
+def create_or_update_optional_attributes(client_id):
     """
     Updates optional fields on 'ClientRegistrations' Table
     """
@@ -261,7 +261,7 @@ def update_optional_attributes(client_id):
         # Check if client_id is associated with the Cognito user_id which executed the request
         associated_client_id = extract_client_id_from_connected_user(user_id)
         if associated_client_id != client_id:
-            logger.error("[update_optional_attributes]: client_id is not associated with the provided user_id")
+            logger.error("[create_or_update_optional_attributes]: client_id is not associated with the provided user_id")
             return {"message": "client_id is not associated with the provided user_id"}, 403
 
         # Extract optional attributes from the request body
@@ -270,10 +270,10 @@ def update_optional_attributes(client_id):
         localized_content = body.get("localizedContentMap")
 
         localized_content_map_object = LocalizedContentMap.from_json(localized_content)
-        logger.debug("[update_optional_attributes]: %s", localized_content_map_object)
+        logger.debug("[create_or_update_optional_attributes]: %s", localized_content_map_object)
         localized_content_map_object_value = localized_content_map_object.to_dynamodb()
         logger.debug(
-            "[update_optional_attributes]: %s", localized_content_map_object_value
+            "[create_or_update_optional_attributes]: %s", localized_content_map_object_value
         )
         # Update the optional attributes in DynamoDB in ClientRegistrations table
         response = dynamodb_client.update_item(
@@ -286,11 +286,11 @@ def update_optional_attributes(client_id):
                 ":localizedContentMap": localized_content_map_object_value,
             },
         )
-        logger.debug("[update_optional_attributes]: %s", response)
+        logger.debug("[create_or_update_optional_attributes]: %s", response)
 
         # Check if the response indicates success
         if response.get("ResponseMetadata", {}).get("HTTPStatusCode") != 200:
-            logger.error("[update_optional_attributes]: %s", response)
+            logger.error("[create_or_update_optional_attributes]: %s", response)
             return {"message": "Failed to update optional attributes"}, 500
 
         # Return success response

--- a/src/oneid/oneid-lambda-client-manager/index.py
+++ b/src/oneid/oneid-lambda-client-manager/index.py
@@ -152,7 +152,7 @@ def update_user_attributes_with_client_id():
     """
     Inserts 'client_id' inside Cognito User Attributes
     """
-    logger.info("/admin/client-manager/user-attributes route invoked")
+    logger.info("/client-manager/user-attributes route invoked")
     try:
         # Parse the JSON body of the request
         body = app.current_event.json_body
@@ -199,7 +199,7 @@ def update_optional_attributes(client_id):
     """
     Updates optional fields on 'ClientRegistrations' Table
     """
-    logger.info("/admin/client-manager/client-additional route invoked")
+    logger.info("/client-manager/client-additional route invoked")
     try:
         # Parse the JSON body of the request
         body = app.current_event.json_body
@@ -257,7 +257,7 @@ def create_idp_internal_user():
     """
     Creates a user in the Internal IDP
     """
-    logger.info("/admin/client-manager/client-users POST route invoked")
+    logger.info("/client-manager/client-users POST route invoked")
     try:
         # Parse the JSON body of the request
         body = app.current_event.json_body
@@ -339,7 +339,7 @@ def update_idp_internal_user(user_id: str, username: str):
     """
     Updates a user in the Internal IDP
     """
-    logger.info("/admin/client-manager/client-users PUT route invoked")
+    logger.info("/client-manager/client-users PUT route invoked")
     try:
         # Parse the JSON body of the request
         body = app.current_event.json_body
@@ -408,7 +408,7 @@ def delete_idp_internal_user(user_id: str, username: str):
     """
     Deletes a user in the Internal IDP
     """
-    logger.info("/admin/client-manager/client-users DELETE route invoked")
+    logger.info("/client-manager/client-users DELETE route invoked")
     try:
         # Extract the client_id from the cognito user attributes
         client_id = extract_client_id_from_connected_user(user_id)
@@ -445,7 +445,7 @@ def get_idp_internal_users(user_id: str):
     """
     Retrieves all users of a client in the Internal IDP
     """
-    logger.info("/admin/client-manager/client-users GET route invoked")
+    logger.info("/client-manager/client-users GET route invoked")
     try:
         # Extract the client_id from the cognito user attributes
         client_id = extract_client_id_from_connected_user(user_id)

--- a/src/oneid/oneid-lambda-client-manager/localized_content_map.py
+++ b/src/oneid/oneid-lambda-client-manager/localized_content_map.py
@@ -81,3 +81,27 @@ class LocalizedContentMap:
             for language, themes in json_data.items()
         }
         return cls(content_map=content_map)
+    
+
+    @classmethod
+    def from_dynamodb(cls, dynamodb_data: Dict) -> "LocalizedContentMap":
+        """
+        Construct a LocalizedContentMap object from a DynamoDB-formatted dictionary.
+        :param dynamodb_data: The DynamoDB dictionary containing the content map.
+        :return: A LocalizedContentMap object.
+        """
+        content_map = {}
+        languages = dynamodb_data.get("M", {})
+        for language, lang_data in languages.items():
+            themes = lang_data.get("M", {})
+            content_map[language] = {}
+            for key, theme_data in themes.items():
+                theme_fields = theme_data.get("M", {})
+                content_map[language][key] = Theme(
+                    title=theme_fields.get("title", {}).get("S", ""),
+                    desc=theme_fields.get("desc", {}).get("S", ""),
+                    doc_uri=theme_fields.get("doc_uri", {}).get("S", ""),
+                    support_address=theme_fields.get("support_address", {}).get("S", ""),
+                    cookie_uri=theme_fields.get("cookie_uri", {}).get("S", "")
+                )
+        return cls(content_map=content_map)

--- a/src/oneid/oneid-lambda-client-manager/test_index.py
+++ b/src/oneid/oneid-lambda-client-manager/test_index.py
@@ -4,7 +4,7 @@ Unit tests for index.py
 import unittest
 from unittest.mock import patch, Mock
 from index import check_client_id_exists, get_cognito_client, get_dynamodb_client, \
-    update_optional_attributes, update_user_attributes_with_client_id, get_optional_attributes
+    create_or_update_optional_attributes, update_user_attributes_with_client_id, get_optional_attributes
 
 
 class TestCheckClientIdExists(unittest.TestCase):
@@ -254,7 +254,7 @@ class TestUpdateOptionalAttributes(unittest.TestCase):
         mock_update_item.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
         mock_getenv.return_value = "test_table"
 
-        response, status_code = update_optional_attributes("test_client_id")
+        response, status_code = create_or_update_optional_attributes("test_client_id")
 
         self.assertEqual(status_code, 200)
         self.assertEqual(response["message"], "Optional attributes updated successfully")
@@ -313,7 +313,7 @@ class TestUpdateOptionalAttributes(unittest.TestCase):
         mock_check_client_id_exists.return_value = False
         mock_getenv.return_value = "test_table"
 
-        response, status_code = update_optional_attributes("nonexistent_client_id")
+        response, status_code = create_or_update_optional_attributes("nonexistent_client_id")
 
         self.assertEqual(status_code, 404)
         self.assertEqual(response["message"], "client_id not found")
@@ -366,7 +366,7 @@ class TestUpdateOptionalAttributes(unittest.TestCase):
         mock_update_item.return_value = {"ResponseMetadata": {"HTTPStatusCode": 500}}
         mock_getenv.return_value = "test_table"
 
-        response, status_code = update_optional_attributes("test_client_id")
+        response, status_code = create_or_update_optional_attributes("test_client_id")
 
         self.assertEqual(status_code, 500)
         self.assertEqual(response["message"], "Failed to update optional attributes")
@@ -425,7 +425,7 @@ class TestUpdateOptionalAttributes(unittest.TestCase):
         mock_check_client_id_exists.side_effect = Exception("Unexpected error")
         mock_getenv.return_value = "test_table"
 
-        response, status_code = update_optional_attributes("test_client_id")
+        response, status_code = create_or_update_optional_attributes("test_client_id")
 
         self.assertEqual(status_code, 500)
         self.assertEqual(response["message"], "Internal server error")


### PR DESCRIPTION
This **PR**:
- adds the route `/client-manager/client-additional/<client_id>` to retrieve additional fields of a given client;
- fixes something;
- updates the ClientManager's OpenAPI file.