### PR TITLE
refactor: Remove KMS KeyId references

### DIFF
--- a/src/infra/modules/backend/ecs.tf
+++ b/src/infra/modules/backend/ecs.tf
@@ -179,18 +179,6 @@ resource "aws_iam_policy" "ecs_core_task" {
           }
         }
       },
-      #TODO: remove after deploying with alias ref
-      {
-        Sid    = "KSMSignKeyId"
-        Effect = "Allow"
-        Action = [
-          "kms:Sign",
-          "kms:GetPublicKey",
-        ]
-        Resource = [
-          "${module.jwt_sign.aliases.sign-jwt.target_key_arn}"
-        ]
-      },
       {
         Sid    = "KMSDecryptEncryptSessions"
         Effect = "Allow"
@@ -390,11 +378,6 @@ module "ecs_core_service" {
         {
           name  = "SIGN_JWT_KEY_ALIAS"
           value = module.jwt_sign.aliases.sign-jwt.name
-        },
-        #TODO: remove after deploying with alias ref
-        {
-          name  = "KMS_KEY_ID"
-          value = module.jwt_sign.aliases.sign-jwt.target_key_id
         }
       ])
 


### PR DESCRIPTION
With this PR we finalize the switch from kms `KeyId` to `alias` used by the sign method