### PR TITLE
feat(OI-418): add csp policy for oneidentity and internal portal (report-only)

### DIFF
--- a/src/infra/api/oi-admin.tpl.json
+++ b/src/infra/api/oi-admin.tpl.json
@@ -836,7 +836,8 @@
             "200": {
               "statusCode": "200",
               "responseParameters": {
-                "method.response.header.content-type": "integration.response.header.Content-Type"
+                "method.response.header.content-type": "integration.response.header.Content-Type",
+                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.pagopa.it; connect-src 'self' https://*.pagopa.it;'"
               }
             },
             "404": {
@@ -881,7 +882,8 @@
             "200": {
               "statusCode": "200",
               "responseParameters": {
-                "method.response.header.content-type": "integration.response.header.Content-Type"
+                "method.response.header.content-type": "integration.response.header.Content-Type",
+                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.pagopa.it; connect-src 'self' https://*.pagopa.it;'"
               }
             },
             "404": {
@@ -925,6 +927,9 @@
                 "schema": {
                   "type": "string"
                 }
+              },
+              "Content-Security-Policy-Report-Only": {
+                "type": "string"
               }
             },
             "content": {}
@@ -942,7 +947,8 @@
             "default": {
               "statusCode": "200",
               "responseParameters": {
-                "method.response.header.Content-Type": "integration.response.header.Content-Type"
+                "method.response.header.Content-Type": "integration.response.header.Content-Type",
+                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.pagopa.it;'"
               }
             },
             "404": {
@@ -1036,7 +1042,10 @@
                 "type": "string"
               }
             }
-          }
+          },
+            "Content-Security-Policy-Report-Only": {
+            "type": "string"
+            }
         },
         "content": {
           "text/html": {

--- a/src/infra/api/oi-admin.tpl.json
+++ b/src/infra/api/oi-admin.tpl.json
@@ -837,7 +837,7 @@
               "statusCode": "200",
               "responseParameters": {
                 "method.response.header.content-type": "integration.response.header.Content-Type",
-                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.pagopa.it; connect-src 'self' https://*.pagopa.it;'"
+                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.pagopa.it; connect-src 'self' https://*.pagopa.it; frame-ancestors 'none';'"
               }
             },
             "404": {
@@ -883,7 +883,7 @@
               "statusCode": "200",
               "responseParameters": {
                 "method.response.header.content-type": "integration.response.header.Content-Type",
-                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.pagopa.it; connect-src 'self' https://*.pagopa.it;'"
+                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.pagopa.it; connect-src 'self' https://*.pagopa.it; frame-ancestors 'none';'"
               }
             },
             "404": {
@@ -948,7 +948,7 @@
               "statusCode": "200",
               "responseParameters": {
                 "method.response.header.Content-Type": "integration.response.header.Content-Type",
-                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.pagopa.it;'"
+                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.pagopa.it; frame-ancestors 'none';'"
               }
             },
             "404": {

--- a/src/infra/api/oi.tpl.json
+++ b/src/infra/api/oi.tpl.json
@@ -194,7 +194,8 @@
               "statusCode": "200",
               "responseParameters": {
                 "method.response.header.content-type": "integration.response.header.Content-Type",
-                "method.response.header.location": "integration.response.header.location"
+                "method.response.header.location": "integration.response.header.location",
+                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;'"
               }
             },
             "404": {
@@ -244,7 +245,9 @@
             "200": {
               "statusCode": "200",
               "responseParameters": {
-                "method.response.header.content-type": "integration.response.header.Content-Type"
+                "method.response.header.content-type": "integration.response.header.Content-Type",
+                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;'"
+
               }
             },
             "404": {
@@ -2057,7 +2060,9 @@
             "default": {
               "statusCode": "200",
               "responseParameters": {
-                "method.response.header.Content-Type": "integration.response.header.Content-Type"
+                "method.response.header.Content-Type": "integration.response.header.Content-Type",
+                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;'"
+
               }
             },
             "404": {
@@ -2117,7 +2122,9 @@
             "default": {
               "statusCode": "200",
               "responseParameters": {
-                "method.response.header.Content-Type": "integration.response.header.Content-Type"
+                "method.response.header.Content-Type": "integration.response.header.Content-Type",
+                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;'"
+
               }
             },
             "404": {

--- a/src/infra/api/oi.tpl.json
+++ b/src/infra/api/oi.tpl.json
@@ -195,7 +195,7 @@
               "responseParameters": {
                 "method.response.header.content-type": "integration.response.header.Content-Type",
                 "method.response.header.location": "integration.response.header.location",
-                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.pagopa.it;'"
+                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.pagopa.it; frame-ancestors 'none';'"
               }
             },
             "404": {
@@ -246,7 +246,7 @@
               "statusCode": "200",
               "responseParameters": {
                 "method.response.header.content-type": "integration.response.header.Content-Type",
-                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.pagopa.it;'"
+                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.pagopa.it; frame-ancestors 'none';'"
               }
             },
             "404": {
@@ -2063,7 +2063,7 @@
               "statusCode": "200",
               "responseParameters": {
                 "method.response.header.Content-Type": "integration.response.header.Content-Type",
-                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.pagopa.it;'"
+                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.pagopa.it; frame-ancestors 'none';'"
               }
             },
             "404": {
@@ -2127,7 +2127,7 @@
               "statusCode": "200",
               "responseParameters": {
                 "method.response.header.Content-Type": "integration.response.header.Content-Type",
-                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.pagopa.it;'"
+                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.pagopa.it; frame-ancestors 'none';'"
               }
             },
             "404": {

--- a/src/infra/api/oi.tpl.json
+++ b/src/infra/api/oi.tpl.json
@@ -195,7 +195,7 @@
               "responseParameters": {
                 "method.response.header.content-type": "integration.response.header.Content-Type",
                 "method.response.header.location": "integration.response.header.location",
-                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;'"
+                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.pagopa.it;'"
               }
             },
             "404": {
@@ -246,8 +246,7 @@
               "statusCode": "200",
               "responseParameters": {
                 "method.response.header.content-type": "integration.response.header.Content-Type",
-                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;'"
-
+                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.pagopa.it;'"
               }
             },
             "404": {
@@ -2043,6 +2042,9 @@
                 "schema": {
                   "type": "string"
                 }
+              },
+              "Content-Security-Policy-Report-Only": {
+                "type": "string"
               }
             },
             "content": {}
@@ -2061,8 +2063,7 @@
               "statusCode": "200",
               "responseParameters": {
                 "method.response.header.Content-Type": "integration.response.header.Content-Type",
-                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;'"
-
+                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.pagopa.it;'"
               }
             },
             "404": {
@@ -2105,6 +2106,9 @@
                 "schema": {
                   "type": "string"
                 }
+              },
+              "Content-Security-Policy-Report-Only": {
+                "type": "string"
               }
             },
             "content": {}
@@ -2123,8 +2127,7 @@
               "statusCode": "200",
               "responseParameters": {
                 "method.response.header.Content-Type": "integration.response.header.Content-Type",
-                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;'"
-
+                "method.response.header.Content-Security-Policy-Report-Only": "'default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.pagopa.it;'"
               }
             },
             "404": {
@@ -2216,6 +2219,9 @@
                 "type": "string"
               }
             }
+          },
+          "Content-Security-Policy-Report-Only": {
+            "type": "string"
           }
         },
         "content": {


### PR DESCRIPTION
This **PR** adds `CSP` for the subsequent routes (temporarily in **report-only:** mode):

OneIdentity:

- `/login`
- `/login/error`
- `/static/{proxy+}`
- `/assets/{proxy+}`

`Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.pagopa.it; frame-ancestors 'none';`

Internal IDP:
- `/assets/{proxy+}`

`Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.pagopa.it; frame-ancestors 'none';`

- `/dashboard`
- `/dashboard/{clientId+}`

`Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://*.pagopa.it; connect-src 'self' https://*.pagopa.it; frame-ancestors 'none';`



