### PR TITLE
feat: pdv namespaced token integration

### DIFF
--- a/src/infra/api/oi.tpl.json
+++ b/src/infra/api/oi.tpl.json
@@ -3186,6 +3186,10 @@
             "type": "boolean",
             "description": "Indicates whether the user authenticated with the same Identity Provider as the previous session. This is useful for Single Sign-On (SSO) scenarios."
           },
+          "pairwise": {
+            "type": "string",
+            "description": "PDV namespaced token. This claim is present only if the client has registered for pairwise subject identifiers."
+          },
           "iat": {
             "type": "integer",
             "format": "int64",

--- a/src/infra/dev/eu-south-1/main.tf
+++ b/src/infra/dev/eu-south-1/main.tf
@@ -240,6 +240,10 @@ module "backend" {
       {
         name  = "CLOUDWATCH_CUSTOM_METRIC_NAMESPACE"
         value = format("%s/%s", format("%s-core", local.project), var.app_cloudwatch_custom_metric_namespace)
+      },
+      {
+        name  = "PDV_BASE_URL"
+        value = "https://api.dev.pdv.pagopa.it"
       }
     ]
   }

--- a/src/infra/modules/backend/ecs.tf
+++ b/src/infra/modules/backend/ecs.tf
@@ -211,7 +211,8 @@ resource "aws_iam_policy" "ecs_core_task" {
         ],
         "Resource" : [
           "${data.aws_ssm_parameter.certificate.arn}",
-          "${aws_ssm_parameter.key_pem.arn}"
+          "${aws_ssm_parameter.key_pem.arn}",
+          "arn:aws:ssm:${var.aws_region}:${var.account_id}:parameter/pdv/*"
         ]
       },
       {

--- a/src/infra/prod/eu-central-1/main.tf
+++ b/src/infra/prod/eu-central-1/main.tf
@@ -163,6 +163,10 @@ module "backend" {
       {
         name  = "CLOUDWATCH_CUSTOM_METRIC_NAMESPACE"
         value = format("%s/%s", format("%s-core", local.project), var.app_cloudwatch_custom_metric_namespace)
+      },
+      {
+        name  = "PDV_BASE_URL"
+        value = "https://api.pdv.pagopa.it"
       }
     ]
   }

--- a/src/infra/prod/eu-south-1/main.tf
+++ b/src/infra/prod/eu-south-1/main.tf
@@ -211,6 +211,10 @@ module "backend" {
       {
         name  = "CLOUDWATCH_CUSTOM_METRIC_NAMESPACE"
         value = format("%s/%s", format("%s-core", local.project), var.app_cloudwatch_custom_metric_namespace)
+      },
+      {
+        name  = "PDV_BASE_URL"
+        value = "https://api.pdv.pagopa.it"
       }
     ]
   }

--- a/src/infra/uat/eu-south-1/main.tf
+++ b/src/infra/uat/eu-south-1/main.tf
@@ -236,6 +236,10 @@ module "backend" {
       {
         name  = "CLOUDWATCH_CUSTOM_METRIC_NAMESPACE"
         value = format("%s/%s", format("%s-core", local.project), var.app_cloudwatch_custom_metric_namespace)
+      },
+      {
+        name  = "PDV_BASE_URL"
+        value = "https://api.uat.pdv.pagopa.it"
       }
     ]
   }

--- a/src/oneid/oneid-common/connector/src/main/java/it/pagopa/oneid/common/connector/SSMConnector.java
+++ b/src/oneid/oneid-common/connector/src/main/java/it/pagopa/oneid/common/connector/SSMConnector.java
@@ -1,0 +1,9 @@
+package it.pagopa.oneid.common.connector;
+
+import java.util.Optional;
+
+public interface SSMConnector {
+
+  Optional<String> getParameter(String parameterName);
+
+}

--- a/src/oneid/oneid-common/connector/src/main/java/it/pagopa/oneid/common/connector/SSMConnectorImpl.java
+++ b/src/oneid/oneid-common/connector/src/main/java/it/pagopa/oneid/common/connector/SSMConnectorImpl.java
@@ -1,0 +1,27 @@
+package it.pagopa.oneid.common.connector;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.Optional;
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.model.GetParameterRequest;
+import software.amazon.awssdk.services.ssm.model.GetParameterResponse;
+
+@ApplicationScoped
+public class SSMConnectorImpl implements SSMConnector {
+
+  @Inject
+  SsmClient ssmClient;
+
+  @Override
+  public Optional<String> getParameter(String parameterName) {
+    GetParameterRequest request = GetParameterRequest.builder()
+        .name(parameterName)
+        .withDecryption(true)  // Set to true if the parameter is encrypted
+        .build();
+
+    // TODO: manage exceptions from AWS SDK
+    GetParameterResponse response = ssmClient.getParameter(request);
+    return Optional.of(response.parameter().value());
+  }
+}

--- a/src/oneid/oneid-common/utils/src/main/java/it/pagopa/oneid/common/utils/SSMConnectorUtils.java
+++ b/src/oneid/oneid-common/utils/src/main/java/it/pagopa/oneid/common/utils/SSMConnectorUtils.java
@@ -1,8 +1,8 @@
-package it.pagopa.oneid.common.connector;
+package it.pagopa.oneid.common.utils;
 
 import java.util.Optional;
 
-public interface SSMConnector {
+public interface SSMConnectorUtils {
 
   Optional<String> getParameter(String parameterName);
 

--- a/src/oneid/oneid-common/utils/src/main/java/it/pagopa/oneid/common/utils/SSMConnectorUtilsImpl.java
+++ b/src/oneid/oneid-common/utils/src/main/java/it/pagopa/oneid/common/utils/SSMConnectorUtilsImpl.java
@@ -12,7 +12,7 @@ import software.amazon.awssdk.services.ssm.model.SsmException;
 
 @ApplicationScoped
 @CustomLogging
-public class SSMConnectorUtilsUtilsImpl implements SSMConnectorUtils {
+public class SSMConnectorUtilsImpl implements SSMConnectorUtils {
 
   @Inject
   SsmClient ssmClient;

--- a/src/oneid/oneid-common/utils/src/main/java/it/pagopa/oneid/common/utils/SSMConnectorUtilsUtilsImpl.java
+++ b/src/oneid/oneid-common/utils/src/main/java/it/pagopa/oneid/common/utils/SSMConnectorUtilsUtilsImpl.java
@@ -1,5 +1,6 @@
 package it.pagopa.oneid.common.utils;
 
+import io.quarkus.logging.Log;
 import it.pagopa.oneid.common.utils.logging.CustomLogging;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -7,6 +8,7 @@ import java.util.Optional;
 import software.amazon.awssdk.services.ssm.SsmClient;
 import software.amazon.awssdk.services.ssm.model.GetParameterRequest;
 import software.amazon.awssdk.services.ssm.model.GetParameterResponse;
+import software.amazon.awssdk.services.ssm.model.SsmException;
 
 @ApplicationScoped
 @CustomLogging
@@ -22,8 +24,14 @@ public class SSMConnectorUtilsUtilsImpl implements SSMConnectorUtils {
         .withDecryption(true)  // Set to true if the parameter is encrypted
         .build();
 
-    // TODO: manage exceptions from AWS SDK
-    GetParameterResponse response = ssmClient.getParameter(request);
+    GetParameterResponse response;
+
+    try {
+      response = ssmClient.getParameter(request);
+    } catch (SsmException e) {
+      Log.error("Error retrieving parameter from SSM: " + e.awsErrorDetails().errorMessage());
+      return Optional.empty();
+    }
     return Optional.of(response.parameter().value());
   }
 }

--- a/src/oneid/oneid-common/utils/src/main/java/it/pagopa/oneid/common/utils/SSMConnectorUtilsUtilsImpl.java
+++ b/src/oneid/oneid-common/utils/src/main/java/it/pagopa/oneid/common/utils/SSMConnectorUtilsUtilsImpl.java
@@ -1,5 +1,6 @@
-package it.pagopa.oneid.common.connector;
+package it.pagopa.oneid.common.utils;
 
+import it.pagopa.oneid.common.utils.logging.CustomLogging;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.Optional;
@@ -8,7 +9,8 @@ import software.amazon.awssdk.services.ssm.model.GetParameterRequest;
 import software.amazon.awssdk.services.ssm.model.GetParameterResponse;
 
 @ApplicationScoped
-public class SSMConnectorImpl implements SSMConnector {
+@CustomLogging
+public class SSMConnectorUtilsUtilsImpl implements SSMConnectorUtils {
 
   @Inject
   SsmClient ssmClient;

--- a/src/oneid/oneid-common/utils/src/main/java/it/pagopa/oneid/common/utils/config/ConfigBasicX509Credential.java
+++ b/src/oneid/oneid-common/utils/src/main/java/it/pagopa/oneid/common/utils/config/ConfigBasicX509Credential.java
@@ -1,7 +1,7 @@
 package it.pagopa.oneid.common.utils.config;
 
 import io.quarkus.logging.Log;
-import it.pagopa.oneid.common.utils.SSMConnectorUtilsUtilsImpl;
+import it.pagopa.oneid.common.utils.SSMConnectorUtilsImpl;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.Produces;
@@ -30,7 +30,7 @@ public class ConfigBasicX509Credential {
   String keyName;
 
   @Inject
-  SSMConnectorUtilsUtilsImpl ssmConnectorUtilsImpl;
+  SSMConnectorUtilsImpl ssmConnectorUtilsImpl;
 
   @Singleton
   @Produces
@@ -81,5 +81,5 @@ public class ConfigBasicX509Credential {
 
     return basicX509Credential;
   }
-  
+
 }

--- a/src/oneid/oneid-common/utils/src/main/java/it/pagopa/oneid/common/utils/config/ConfigBasicX509Credential.java
+++ b/src/oneid/oneid-common/utils/src/main/java/it/pagopa/oneid/common/utils/config/ConfigBasicX509Credential.java
@@ -80,6 +80,7 @@ public class ConfigBasicX509Credential {
     return basicX509Credential;
   }
 
+  // TODO: remove this method and use a common utility class
   private String getParameter(SsmClient ssmClient, String parameterName) {
     GetParameterRequest request = GetParameterRequest.builder()
         .name(parameterName)

--- a/src/oneid/oneid-ecs-core/dep-sha256.json
+++ b/src/oneid/oneid-ecs-core/dep-sha256.json
@@ -1597,13 +1597,6 @@
       "sha256": "HnMBHvqvpDfestIjihvKA8QSFZOteOZkf8QqECPGJgo="
     },
     {
-      "id": "io.quarkus.resteasy.reactive:resteasy-reactive-jackson:jar:3.11.3",
-      "artifactId": "resteasy-reactive-jackson",
-      "groupId": "io.quarkus.resteasy.reactive",
-      "version": "3.11.3",
-      "sha256": "sdAqGmFcCPqAv56rq4jh914HtMkA2NZ7OQqHCtDWPgY="
-    },
-    {
       "id": "io.quarkus:quarkus-jackson:jar:3.11.3",
       "artifactId": "quarkus-jackson",
       "groupId": "io.quarkus",
@@ -1623,6 +1616,83 @@
       "groupId": "com.fasterxml.jackson.module",
       "version": "2.17.1",
       "sha256": "VaDFSoLDBSSYEzXHg14ybKCfSJzw9dXio0tcTGzBoKU="
+    },
+    {
+      "id": "io.quarkus:quarkus-rest-client-jackson:jar:3.11.3",
+      "artifactId": "quarkus-rest-client-jackson",
+      "groupId": "io.quarkus",
+      "version": "3.11.3",
+      "sha256": "b00EAeuJNeQxpzoFZTzH8HtiksFSFZguNtFel9nVsn8="
+    },
+    {
+      "id": "io.quarkus.resteasy.reactive:resteasy-reactive-jackson:jar:3.11.3",
+      "artifactId": "resteasy-reactive-jackson",
+      "groupId": "io.quarkus.resteasy.reactive",
+      "version": "3.11.3",
+      "sha256": "sdAqGmFcCPqAv56rq4jh914HtMkA2NZ7OQqHCtDWPgY="
+    },
+    {
+      "id": "com.fasterxml.jackson.core:jackson-databind:jar:2.17.1",
+      "artifactId": "jackson-databind",
+      "groupId": "com.fasterxml.jackson.core",
+      "version": "2.17.1",
+      "sha256": "tsovfVsaskXOxUlewzl3PS2QVUxIWSWQZz-xj0QAqUg="
+    },
+    {
+      "id": "io.quarkus:quarkus-rest-client:jar:3.11.3",
+      "artifactId": "quarkus-rest-client",
+      "groupId": "io.quarkus",
+      "version": "3.11.3",
+      "sha256": "YSfoRPWRzAq3lxsYxvEWHa_3Yzd9k7tD9djVWv9WtWU="
+    },
+    {
+      "id": "io.quarkus:quarkus-rest-client-jaxrs:jar:3.11.3",
+      "artifactId": "quarkus-rest-client-jaxrs",
+      "groupId": "io.quarkus",
+      "version": "3.11.3",
+      "sha256": "whXKwtxKvjDnhl0kRFE3I2ZoekwT9MeRarD5aDxMpKM="
+    },
+    {
+      "id": "io.quarkus.resteasy.reactive:resteasy-reactive-client:jar:3.11.3",
+      "artifactId": "resteasy-reactive-client",
+      "groupId": "io.quarkus.resteasy.reactive",
+      "version": "3.11.3",
+      "sha256": "SAXvEnLL7k2jd0HVq5OKgijMAshMIJ30zpxPMND2-qs="
+    },
+    {
+      "id": "io.quarkus:quarkus-smallrye-stork:jar:3.11.3",
+      "artifactId": "quarkus-smallrye-stork",
+      "groupId": "io.quarkus",
+      "version": "3.11.3",
+      "sha256": "pYX3_pKBMydPpY3YfFhgPq_XORcG8VGZiVxTJs0ZLj8="
+    },
+    {
+      "id": "io.quarkus:quarkus-rest-client-config:jar:3.11.3",
+      "artifactId": "quarkus-rest-client-config",
+      "groupId": "io.quarkus",
+      "version": "3.11.3",
+      "sha256": "wqV9jc3891lIu_I0PNuSkx_RrEIClMGODzpKEjlNhnc="
+    },
+    {
+      "id": "io.smallrye.stork:stork-api:jar:2.6.0",
+      "artifactId": "stork-api",
+      "groupId": "io.smallrye.stork",
+      "version": "2.6.0",
+      "sha256": "T-mRsWK7Qkln55Nk5p5aqgDhSAXHQ7r-yZWT0rD15jI="
+    },
+    {
+      "id": "io.smallrye.stork:stork-core:jar:2.6.0",
+      "artifactId": "stork-core",
+      "groupId": "io.smallrye.stork",
+      "version": "2.6.0",
+      "sha256": "T_aqyApgFPtHcDSW7xcXwslWIioP1kR1dop6mryDLIw="
+    },
+    {
+      "id": "org.eclipse.microprofile.rest.client:microprofile-rest-client-api:jar:3.0.1",
+      "artifactId": "microprofile-rest-client-api",
+      "groupId": "org.eclipse.microprofile.rest.client",
+      "version": "3.0.1",
+      "sha256": "K3Fpi5XIksxlkjX0_-ZjteLxFRzrTncmiyP_KwxjIcs="
     },
     {
       "id": "io.quarkus:quarkus-smallrye-openapi:jar:3.11.3",
@@ -1651,13 +1721,6 @@
       "groupId": "com.fasterxml.jackson.core",
       "version": "2.17.1",
       "sha256": "3bJsih8ahFNeghPEizWyUzcENOMoezzxV3eFb8TljOY="
-    },
-    {
-      "id": "com.fasterxml.jackson.core:jackson-databind:jar:2.17.1",
-      "artifactId": "jackson-databind",
-      "groupId": "com.fasterxml.jackson.core",
-      "version": "2.17.1",
-      "sha256": "tsovfVsaskXOxUlewzl3PS2QVUxIWSWQZz-xj0QAqUg="
     },
     {
       "id": "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.17.1",

--- a/src/oneid/oneid-ecs-core/pom.xml
+++ b/src/oneid/oneid-ecs-core/pom.xml
@@ -121,6 +121,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-openapi</artifactId>
         </dependency>
         <dependency>

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/PDVApiClient.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/PDVApiClient.java
@@ -2,11 +2,10 @@ package it.pagopa.oneid.connector;
 
 import it.pagopa.oneid.model.dto.PDVUserUpsertResponseDTO;
 import it.pagopa.oneid.model.dto.SavePDVUserDTO;
-import jakarta.validation.Valid;
-import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.Path;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 @RegisterRestClient(configKey = "pdv-api")
@@ -15,7 +14,7 @@ public interface PDVApiClient {
 
   @PATCH
   PDVUserUpsertResponseDTO upsertUser(
-      @BeanParam @Valid SavePDVUserDTO savePDVUserDTO,
-      @HeaderParam("X-API-Key") String apiKey
+      @RequestBody SavePDVUserDTO savePDVUserDTO,
+      @HeaderParam("x-api-key") String apiKey
   );
 }

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/PDVApiClient.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/connector/PDVApiClient.java
@@ -1,0 +1,21 @@
+package it.pagopa.oneid.connector;
+
+import it.pagopa.oneid.model.dto.PDVUserUpsertResponseDTO;
+import it.pagopa.oneid.model.dto.SavePDVUserDTO;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.Path;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+@RegisterRestClient(configKey = "pdv-api")
+@Path("/user-registry/v1/users")
+public interface PDVApiClient {
+
+  @PATCH
+  PDVUserUpsertResponseDTO upsertUser(
+      @BeanParam @Valid SavePDVUserDTO savePDVUserDTO,
+      @HeaderParam("X-API-Key") String apiKey
+  );
+}

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/dto/CertifiedField.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/dto/CertifiedField.java
@@ -1,5 +1,6 @@
 package it.pagopa.oneid.model.dto;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -8,8 +9,11 @@ import lombok.NoArgsConstructor;
 public class CertifiedField<T> {
 
   private static final String CERTIFIED_FIELD_VALUE = "SPID";
-  
+
+  @NotNull
   private String certification;
+
+  @NotNull
   private T value;
 
   public CertifiedField(T value) {

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/dto/CertifiedField.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/dto/CertifiedField.java
@@ -1,0 +1,19 @@
+package it.pagopa.oneid.model.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class CertifiedField<T> {
+
+  private static final String CERTIFIED_FIELD_VALUE = "SPID";
+  
+  private String certification;
+  private T value;
+
+  public CertifiedField(T value) {
+    this.certification = CERTIFIED_FIELD_VALUE;
+    this.value = value;
+  }
+}

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/dto/PDVUserUpsertResponseDTO.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/dto/PDVUserUpsertResponseDTO.java
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class PDVUserUpsertResponseDTO {
 
   @JsonProperty("id")

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/dto/PDVUserUpsertResponseDTO.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/dto/PDVUserUpsertResponseDTO.java
@@ -1,0 +1,15 @@
+package it.pagopa.oneid.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class PDVUserUpsertResponseDTO {
+
+  @JsonProperty("id")
+  @NotNull
+  String userId;
+}

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/dto/PDVUserUpsertResponseDTO.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/dto/PDVUserUpsertResponseDTO.java
@@ -3,12 +3,14 @@ package it.pagopa.oneid.model.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class PDVUserUpsertResponseDTO {
 
   @JsonProperty("id")

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/dto/SavePDVUserDTO.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/dto/SavePDVUserDTO.java
@@ -1,14 +1,15 @@
 package it.pagopa.oneid.model.dto;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
 @Data
-@AllArgsConstructor
 @Builder
-public class AttributeDTO {
+@AllArgsConstructor
+public class SavePDVUserDTO {
 
-  String attributeName;
-  String attributeValue;
+  @NotNull
+  String fiscalCode;
 }

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/dto/SavePDVUserDTO.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/dto/SavePDVUserDTO.java
@@ -1,6 +1,8 @@
 package it.pagopa.oneid.model.dto;
 
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -10,6 +12,205 @@ import lombok.Data;
 @AllArgsConstructor
 public class SavePDVUserDTO {
 
+  private static final String FISCAL_CODE_PREFIX = "TINIT-";
+
+
   @NotNull
   String fiscalCode;
+
+  String name;
+
+  String familyName;
+
+  String email;
+
+  LocalDate birthDate;
+
+  String spidCode;
+
+  String placeOfBirth;
+
+  String countyOfBirth;
+
+  String gender;
+
+  String companyName;
+
+  String registeredOffice;
+
+  String ivaCode;
+
+  String idCard;
+
+  String mobilePhone;
+
+  String address;
+
+  LocalDate expirationDate;
+
+  String digitalAddress;
+
+  String domicileAddress;
+
+  String domicilePlace;
+
+  String domicilePostalCode;
+
+  String domicileProvince;
+
+  String domicileCountry;
+
+  String qualification;
+
+  String commonName;
+
+  String surname;
+
+  String givenName;
+
+  String preferredUsername;
+
+  String title;
+
+  String userCertificate;
+
+  String employeeNumber;
+
+  String orgUnitName;
+
+  String preferredLanguage;
+
+  String country;
+
+  String stateOrProvince;
+
+  String city;
+
+  String postalCode;
+
+  String street;
+
+  public static SavePDVUserDTO fromAttributeDtoList(List<AttributeDTO> attributeDTOList) {
+    SavePDVUserDTO.SavePDVUserDTOBuilder builder = SavePDVUserDTO.builder();
+
+    for (AttributeDTO attr : attributeDTOList) {
+      switch (attr.getAttributeName()) {
+        case "fiscalCode":
+          builder.fiscalCode(attr.getAttributeValue().replace(FISCAL_CODE_PREFIX, ""));
+          break;
+        case "name":
+          builder.name(attr.getAttributeValue());
+          break;
+        case "familyName":
+          builder.familyName(attr.getAttributeValue());
+          break;
+        case "email":
+          builder.email(attr.getAttributeValue());
+          break;
+        case "birthDate":
+          builder.birthDate(LocalDate.parse(attr.getAttributeValue()));
+          break;
+        case "spidCode":
+          builder.spidCode(attr.getAttributeValue());
+          break;
+        case "placeOfBirth":
+          builder.placeOfBirth(attr.getAttributeValue());
+          break;
+        case "countyOfBirth":
+          builder.countyOfBirth(attr.getAttributeValue());
+          break;
+        case "gender":
+          builder.gender(attr.getAttributeValue());
+          break;
+        case "companyName":
+          builder.companyName(attr.getAttributeValue());
+          break;
+        case "registeredOffice":
+          builder.registeredOffice(attr.getAttributeValue());
+          break;
+        case "ivaCode":
+          builder.ivaCode(attr.getAttributeValue());
+          break;
+        case "idCard":
+          builder.idCard(attr.getAttributeValue());
+          break;
+        case "mobilePhone":
+          builder.mobilePhone(attr.getAttributeValue());
+          break;
+        case "address":
+          builder.address(attr.getAttributeValue());
+          break;
+        case "expirationDate":
+          builder.expirationDate(LocalDate.parse(attr.getAttributeValue()));
+          break;
+        case "digitalAddress":
+          builder.digitalAddress(attr.getAttributeValue());
+          break;
+        case "domicileAddress":
+          builder.domicileAddress(attr.getAttributeValue());
+          break;
+        case "domicilePlace":
+          builder.domicilePlace(attr.getAttributeValue());
+          break;
+        case "domicilePostalCode":
+          builder.domicilePostalCode(attr.getAttributeValue());
+          break;
+        case "domicileProvince":
+          builder.domicileProvince(attr.getAttributeValue());
+          break;
+        case "domicileCountry":
+          builder.domicileCountry(attr.getAttributeValue());
+          break;
+        case "qualification":
+          builder.qualification(attr.getAttributeValue());
+          break;
+        case "commonName":
+          builder.commonName(attr.getAttributeValue());
+          break;
+        case "surname":
+          builder.surname(attr.getAttributeValue());
+          break;
+        case "givenName":
+          builder.givenName(attr.getAttributeValue());
+          break;
+        case "preferredUsername":
+          builder.preferredUsername(attr.getAttributeValue());
+          break;
+        case "title":
+          builder.title(attr.getAttributeValue());
+          break;
+        case "userCertificate":
+          builder.userCertificate(attr.getAttributeValue());
+          break;
+        case "employeeNumber":
+          builder.employeeNumber(attr.getAttributeValue());
+          break;
+        case "orgUnitName":
+          builder.orgUnitName(attr.getAttributeValue());
+          break;
+        case "preferredLanguage":
+          builder.preferredLanguage(attr.getAttributeValue());
+          break;
+        case "country":
+          builder.country(attr.getAttributeValue());
+          break;
+        case "stateOrProvince":
+          builder.stateOrProvince(attr.getAttributeValue());
+          break;
+        case "city":
+          builder.city(attr.getAttributeValue());
+          break;
+        case "postalCode":
+          builder.postalCode(attr.getAttributeValue());
+          break;
+        case "street":
+          builder.street(attr.getAttributeValue());
+          break;
+        
+      }
+    }
+
+    return builder.build();
+  }
+
 }

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/dto/SavePDVUserDTO.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/dto/SavePDVUserDTO.java
@@ -15,7 +15,7 @@ public class SavePDVUserDTO {
   private static final String FISCAL_CODE_PREFIX = "TINIT-";
 
   @NotNull
-  private CertifiedField<String> fiscalCode;
+  private String fiscalCode;
 
   private CertifiedField<String> name;
 
@@ -95,8 +95,7 @@ public class SavePDVUserDTO {
     for (AttributeDTO attr : attributeDTOList) {
       switch (attr.getAttributeName()) {
         case "fiscalNumber":
-          builder.fiscalCode(
-              new CertifiedField<>(attr.getAttributeValue().replace(FISCAL_CODE_PREFIX, "")));
+          builder.fiscalCode(attr.getAttributeValue().replace(FISCAL_CODE_PREFIX, ""));
           break;
         case "name":
           builder.name(new CertifiedField<>(attr.getAttributeValue()));

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/dto/SavePDVUserDTO.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/dto/SavePDVUserDTO.java
@@ -94,7 +94,7 @@ public class SavePDVUserDTO {
 
     for (AttributeDTO attr : attributeDTOList) {
       switch (attr.getAttributeName()) {
-        case "fiscalCode":
+        case "fiscalNumber":
           builder.fiscalCode(
               new CertifiedField<>(attr.getAttributeValue().replace(FISCAL_CODE_PREFIX, "")));
           break;

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/dto/SavePDVUserDTO.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/dto/SavePDVUserDTO.java
@@ -14,81 +14,80 @@ public class SavePDVUserDTO {
 
   private static final String FISCAL_CODE_PREFIX = "TINIT-";
 
-
   @NotNull
-  String fiscalCode;
+  private CertifiedField<String> fiscalCode;
 
-  String name;
+  private CertifiedField<String> name;
 
-  String familyName;
+  private CertifiedField<String> familyName;
 
-  String email;
+  private CertifiedField<String> email;
 
-  LocalDate birthDate;
+  private CertifiedField<LocalDate> birthDate;
 
-  String spidCode;
+  private CertifiedField<String> spidCode;
 
-  String placeOfBirth;
+  private CertifiedField<String> placeOfBirth;
 
-  String countyOfBirth;
+  private CertifiedField<String> countyOfBirth;
 
-  String gender;
+  private CertifiedField<String> gender;
 
-  String companyName;
+  private CertifiedField<String> companyName;
 
-  String registeredOffice;
+  private CertifiedField<String> registeredOffice;
 
-  String ivaCode;
+  private CertifiedField<String> ivaCode;
 
-  String idCard;
+  private CertifiedField<String> idCard;
 
-  String mobilePhone;
+  private CertifiedField<String> mobilePhone;
 
-  String address;
+  private CertifiedField<String> address;
 
-  LocalDate expirationDate;
+  private CertifiedField<LocalDate> expirationDate;
 
-  String digitalAddress;
+  private CertifiedField<String> digitalAddress;
 
-  String domicileAddress;
+  private CertifiedField<String> domicileAddress;
 
-  String domicilePlace;
+  private CertifiedField<String> domicilePlace;
 
-  String domicilePostalCode;
+  private CertifiedField<String> domicilePostalCode;
 
-  String domicileProvince;
+  private CertifiedField<String> domicileProvince;
 
-  String domicileCountry;
+  private CertifiedField<String> domicileCountry;
 
-  String qualification;
+  private CertifiedField<String> qualification;
 
-  String commonName;
+  private CertifiedField<String> commonName;
 
-  String surname;
+  private CertifiedField<String> surname;
 
-  String givenName;
+  private CertifiedField<String> givenName;
 
-  String preferredUsername;
+  private CertifiedField<String> preferredUsername;
 
-  String title;
+  private CertifiedField<String> title;
 
-  String userCertificate;
+  private CertifiedField<String> userCertificate;
 
-  String employeeNumber;
+  private CertifiedField<String> employeeNumber;
 
-  String orgUnitName;
+  private CertifiedField<String> orgUnitName;
 
-  String preferredLanguage;
+  private CertifiedField<String> preferredLanguage;
 
-  String country;
+  private CertifiedField<String> country;
 
-  String stateOrProvince;
+  private CertifiedField<String> stateOrProvince;
 
-  String city;
+  private CertifiedField<String> city;
 
-  String postalCode;
+  private CertifiedField<String> postalCode;
 
-  String street;
+  private CertifiedField<String> street;
 
   public static SavePDVUserDTO fromAttributeDtoList(List<AttributeDTO> attributeDTOList) {
     SavePDVUserDTO.SavePDVUserDTOBuilder builder = SavePDVUserDTO.builder();
@@ -96,117 +95,118 @@ public class SavePDVUserDTO {
     for (AttributeDTO attr : attributeDTOList) {
       switch (attr.getAttributeName()) {
         case "fiscalCode":
-          builder.fiscalCode(attr.getAttributeValue().replace(FISCAL_CODE_PREFIX, ""));
+          builder.fiscalCode(
+              new CertifiedField<>(attr.getAttributeValue().replace(FISCAL_CODE_PREFIX, "")));
           break;
         case "name":
-          builder.name(attr.getAttributeValue());
+          builder.name(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "familyName":
-          builder.familyName(attr.getAttributeValue());
+          builder.familyName(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "email":
-          builder.email(attr.getAttributeValue());
+          builder.email(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "birthDate":
-          builder.birthDate(LocalDate.parse(attr.getAttributeValue()));
+          builder.birthDate(new CertifiedField<>(LocalDate.parse(attr.getAttributeValue())));
           break;
         case "spidCode":
-          builder.spidCode(attr.getAttributeValue());
+          builder.spidCode(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "placeOfBirth":
-          builder.placeOfBirth(attr.getAttributeValue());
+          builder.placeOfBirth(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "countyOfBirth":
-          builder.countyOfBirth(attr.getAttributeValue());
+          builder.countyOfBirth(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "gender":
-          builder.gender(attr.getAttributeValue());
+          builder.gender(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "companyName":
-          builder.companyName(attr.getAttributeValue());
+          builder.companyName(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "registeredOffice":
-          builder.registeredOffice(attr.getAttributeValue());
+          builder.registeredOffice(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "ivaCode":
-          builder.ivaCode(attr.getAttributeValue());
+          builder.ivaCode(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "idCard":
-          builder.idCard(attr.getAttributeValue());
+          builder.idCard(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "mobilePhone":
-          builder.mobilePhone(attr.getAttributeValue());
+          builder.mobilePhone(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "address":
-          builder.address(attr.getAttributeValue());
+          builder.address(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "expirationDate":
-          builder.expirationDate(LocalDate.parse(attr.getAttributeValue()));
+          builder.expirationDate(new CertifiedField<>(LocalDate.parse(attr.getAttributeValue())));
           break;
         case "digitalAddress":
-          builder.digitalAddress(attr.getAttributeValue());
+          builder.digitalAddress(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "domicileAddress":
-          builder.domicileAddress(attr.getAttributeValue());
+          builder.domicileAddress(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "domicilePlace":
-          builder.domicilePlace(attr.getAttributeValue());
+          builder.domicilePlace(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "domicilePostalCode":
-          builder.domicilePostalCode(attr.getAttributeValue());
+          builder.domicilePostalCode(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "domicileProvince":
-          builder.domicileProvince(attr.getAttributeValue());
+          builder.domicileProvince(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "domicileCountry":
-          builder.domicileCountry(attr.getAttributeValue());
+          builder.domicileCountry(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "qualification":
-          builder.qualification(attr.getAttributeValue());
+          builder.qualification(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "commonName":
-          builder.commonName(attr.getAttributeValue());
+          builder.commonName(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "surname":
-          builder.surname(attr.getAttributeValue());
+          builder.surname(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "givenName":
-          builder.givenName(attr.getAttributeValue());
+          builder.givenName(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "preferredUsername":
-          builder.preferredUsername(attr.getAttributeValue());
+          builder.preferredUsername(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "title":
-          builder.title(attr.getAttributeValue());
+          builder.title(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "userCertificate":
-          builder.userCertificate(attr.getAttributeValue());
+          builder.userCertificate(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "employeeNumber":
-          builder.employeeNumber(attr.getAttributeValue());
+          builder.employeeNumber(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "orgUnitName":
-          builder.orgUnitName(attr.getAttributeValue());
+          builder.orgUnitName(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "preferredLanguage":
-          builder.preferredLanguage(attr.getAttributeValue());
+          builder.preferredLanguage(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "country":
-          builder.country(attr.getAttributeValue());
+          builder.country(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "stateOrProvince":
-          builder.stateOrProvince(attr.getAttributeValue());
+          builder.stateOrProvince(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "city":
-          builder.city(attr.getAttributeValue());
+          builder.city(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "postalCode":
-          builder.postalCode(attr.getAttributeValue());
+          builder.postalCode(new CertifiedField<>(attr.getAttributeValue()));
           break;
         case "street":
-          builder.street(attr.getAttributeValue());
+          builder.street(new CertifiedField<>(attr.getAttributeValue()));
           break;
-        
+
       }
     }
 

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/dto/SavePDVUserDTO.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/dto/SavePDVUserDTO.java
@@ -1,5 +1,7 @@
 package it.pagopa.oneid.model.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.List;
@@ -10,6 +12,7 @@ import lombok.Data;
 @Data
 @Builder
 @AllArgsConstructor
+@JsonInclude(Include.NON_NULL)
 public class SavePDVUserDTO {
 
   private static final String FISCAL_CODE_PREFIX = "TINIT-";

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/dto/SavePDVUserDTO.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/model/dto/SavePDVUserDTO.java
@@ -8,6 +8,7 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
 
 @Data
 @Builder
@@ -96,119 +97,121 @@ public class SavePDVUserDTO {
     SavePDVUserDTO.SavePDVUserDTOBuilder builder = SavePDVUserDTO.builder();
 
     for (AttributeDTO attr : attributeDTOList) {
-      switch (attr.getAttributeName()) {
-        case "fiscalNumber":
-          builder.fiscalCode(attr.getAttributeValue().replace(FISCAL_CODE_PREFIX, ""));
-          break;
-        case "name":
-          builder.name(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "familyName":
-          builder.familyName(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "email":
-          builder.email(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "birthDate":
-          builder.birthDate(new CertifiedField<>(LocalDate.parse(attr.getAttributeValue())));
-          break;
-        case "spidCode":
-          builder.spidCode(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "placeOfBirth":
-          builder.placeOfBirth(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "countyOfBirth":
-          builder.countyOfBirth(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "gender":
-          builder.gender(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "companyName":
-          builder.companyName(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "registeredOffice":
-          builder.registeredOffice(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "ivaCode":
-          builder.ivaCode(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "idCard":
-          builder.idCard(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "mobilePhone":
-          builder.mobilePhone(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "address":
-          builder.address(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "expirationDate":
-          builder.expirationDate(new CertifiedField<>(LocalDate.parse(attr.getAttributeValue())));
-          break;
-        case "digitalAddress":
-          builder.digitalAddress(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "domicileAddress":
-          builder.domicileAddress(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "domicilePlace":
-          builder.domicilePlace(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "domicilePostalCode":
-          builder.domicilePostalCode(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "domicileProvince":
-          builder.domicileProvince(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "domicileCountry":
-          builder.domicileCountry(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "qualification":
-          builder.qualification(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "commonName":
-          builder.commonName(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "surname":
-          builder.surname(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "givenName":
-          builder.givenName(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "preferredUsername":
-          builder.preferredUsername(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "title":
-          builder.title(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "userCertificate":
-          builder.userCertificate(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "employeeNumber":
-          builder.employeeNumber(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "orgUnitName":
-          builder.orgUnitName(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "preferredLanguage":
-          builder.preferredLanguage(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "country":
-          builder.country(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "stateOrProvince":
-          builder.stateOrProvince(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "city":
-          builder.city(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "postalCode":
-          builder.postalCode(new CertifiedField<>(attr.getAttributeValue()));
-          break;
-        case "street":
-          builder.street(new CertifiedField<>(attr.getAttributeValue()));
-          break;
+      if (!StringUtils.isBlank(attr.getAttributeValue())) {
+        switch (attr.getAttributeName()) {
+          case "fiscalNumber":
+            builder.fiscalCode(attr.getAttributeValue().replace(FISCAL_CODE_PREFIX, ""));
+            break;
+          case "name":
+            builder.name(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "familyName":
+            builder.familyName(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "email":
+            builder.email(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "birthDate":
+            builder.birthDate(new CertifiedField<>(LocalDate.parse(attr.getAttributeValue())));
+            break;
+          case "spidCode":
+            builder.spidCode(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "placeOfBirth":
+            builder.placeOfBirth(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "countyOfBirth":
+            builder.countyOfBirth(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "gender":
+            builder.gender(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "companyName":
+            builder.companyName(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "registeredOffice":
+            builder.registeredOffice(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "ivaCode":
+            builder.ivaCode(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "idCard":
+            builder.idCard(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "mobilePhone":
+            builder.mobilePhone(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "address":
+            builder.address(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "expirationDate":
+            builder.expirationDate(new CertifiedField<>(LocalDate.parse(attr.getAttributeValue())));
+            break;
+          case "digitalAddress":
+            builder.digitalAddress(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "domicileAddress":
+            builder.domicileAddress(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "domicilePlace":
+            builder.domicilePlace(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "domicilePostalCode":
+            builder.domicilePostalCode(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "domicileProvince":
+            builder.domicileProvince(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "domicileCountry":
+            builder.domicileCountry(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "qualification":
+            builder.qualification(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "commonName":
+            builder.commonName(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "surname":
+            builder.surname(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "givenName":
+            builder.givenName(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "preferredUsername":
+            builder.preferredUsername(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "title":
+            builder.title(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "userCertificate":
+            builder.userCertificate(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "employeeNumber":
+            builder.employeeNumber(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "orgUnitName":
+            builder.orgUnitName(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "preferredLanguage":
+            builder.preferredLanguage(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "country":
+            builder.country(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "stateOrProvince":
+            builder.stateOrProvince(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "city":
+            builder.city(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "postalCode":
+            builder.postalCode(new CertifiedField<>(attr.getAttributeValue()));
+            break;
+          case "street":
+            builder.street(new CertifiedField<>(attr.getAttributeValue()));
+            break;
 
+        }
       }
     }
 

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/OIDCServiceImpl.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/OIDCServiceImpl.java
@@ -27,7 +27,7 @@ import it.pagopa.oneid.common.model.Client;
 import it.pagopa.oneid.common.model.LastIDPUsed;
 import it.pagopa.oneid.common.model.dto.SecretDTO;
 import it.pagopa.oneid.common.utils.HASHUtils;
-import it.pagopa.oneid.common.utils.SSMConnectorUtilsUtilsImpl;
+import it.pagopa.oneid.common.utils.SSMConnectorUtilsImpl;
 import it.pagopa.oneid.common.utils.logging.CustomLogging;
 import it.pagopa.oneid.connector.KMSConnectorImpl;
 import it.pagopa.oneid.connector.PDVApiClient;
@@ -100,7 +100,7 @@ public class OIDCServiceImpl implements OIDCService {
   @Inject
   LastIDPUsedConnectorImpl lastIDPUsedConnectorImpl;
   @Inject
-  SSMConnectorUtilsUtilsImpl ssmConnectorUtilsImpl;
+  SSMConnectorUtilsImpl ssmConnectorUtilsImpl;
   @Inject
   Map<String, Client> clientsMap;
   @Inject

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/OIDCServiceImpl.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/OIDCServiceImpl.java
@@ -23,11 +23,11 @@ import io.quarkus.logging.Log;
 import io.quarkus.runtime.Startup;
 import it.pagopa.oneid.common.connector.ClientConnectorImpl;
 import it.pagopa.oneid.common.connector.LastIDPUsedConnectorImpl;
-import it.pagopa.oneid.common.connector.SSMConnectorImpl;
 import it.pagopa.oneid.common.model.Client;
 import it.pagopa.oneid.common.model.LastIDPUsed;
 import it.pagopa.oneid.common.model.dto.SecretDTO;
 import it.pagopa.oneid.common.utils.HASHUtils;
+import it.pagopa.oneid.common.utils.SSMConnectorUtilsUtilsImpl;
 import it.pagopa.oneid.common.utils.logging.CustomLogging;
 import it.pagopa.oneid.connector.KMSConnectorImpl;
 import it.pagopa.oneid.connector.PDVApiClient;
@@ -98,7 +98,7 @@ public class OIDCServiceImpl implements OIDCService {
   @Inject
   LastIDPUsedConnectorImpl lastIDPUsedConnectorImpl;
   @Inject
-  SSMConnectorImpl ssmConnectorImpl;
+  SSMConnectorUtilsUtilsImpl ssmConnectorUtilsImpl;
   @Inject
   Map<String, Client> clientsMap;
   @Inject
@@ -249,7 +249,7 @@ public class OIDCServiceImpl implements OIDCService {
         SavePDVUserDTO savePDVUserDTO = SavePDVUserDTO.builder().fiscalCode(id).build();
 
         try {
-          ssmConnectorImpl.getParameter(clientId).ifPresentOrElse(
+          ssmConnectorUtilsImpl.getParameter(clientId).ifPresentOrElse(
               apiKey -> {
                 String userId = pdvApiClient.upsertUser(
                     savePDVUserDTO, apiKey).getUserId();

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/OIDCServiceImpl.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/OIDCServiceImpl.java
@@ -77,6 +77,7 @@ import software.amazon.awssdk.services.kms.model.GetPublicKeyResponse;
 public class OIDCServiceImpl implements OIDCService {
 
   private static final long LAST_IDP_USED_TTL = 730; // days
+  private static final String FISCAL_CODE_PREFIX = "TINIT-";
 
   @Inject
   @ConfigProperty(name = "sign_jwt_key_alias")
@@ -246,7 +247,8 @@ public class OIDCServiceImpl implements OIDCService {
       if (id != null) {
         // if fiscalNumber is present, retrieve the token from PDV
 
-        SavePDVUserDTO savePDVUserDTO = SavePDVUserDTO.builder().fiscalCode(id).build();
+        SavePDVUserDTO savePDVUserDTO = SavePDVUserDTO.builder()
+            .fiscalCode(id.replace(FISCAL_CODE_PREFIX, "")).build();
 
         try {
           ssmConnectorUtilsImpl.getParameter(clientId).ifPresentOrElse(

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/OIDCServiceImpl.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/OIDCServiceImpl.java
@@ -78,6 +78,7 @@ public class OIDCServiceImpl implements OIDCService {
 
   private static final long LAST_IDP_USED_TTL = 730; // days
   private static final String FISCAL_CODE_PREFIX = "TINIT-";
+  private static final String PDV_API_KEY_PREFIX = "/pdv/";
 
   @Inject
   @ConfigProperty(name = "sign_jwt_key_alias")
@@ -251,7 +252,7 @@ public class OIDCServiceImpl implements OIDCService {
             .fiscalCode(id.replace(FISCAL_CODE_PREFIX, "")).build();
 
         try {
-          ssmConnectorUtilsImpl.getParameter(clientId).ifPresentOrElse(
+          ssmConnectorUtilsImpl.getParameter(PDV_API_KEY_PREFIX + clientId).ifPresentOrElse(
               apiKey -> {
                 String userId = pdvApiClient.upsertUser(
                     savePDVUserDTO, apiKey).getUserId();

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/OIDCServiceImpl.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/OIDCServiceImpl.java
@@ -77,7 +77,6 @@ import software.amazon.awssdk.services.kms.model.GetPublicKeyResponse;
 public class OIDCServiceImpl implements OIDCService {
 
   private static final long LAST_IDP_USED_TTL = 730; // days
-  private static final String FISCAL_CODE_PREFIX = "TINIT-";
   private static final String PDV_API_KEY_PREFIX = "/pdv/";
 
   @Inject
@@ -248,8 +247,7 @@ public class OIDCServiceImpl implements OIDCService {
       if (id != null) {
         // if fiscalNumber is present, retrieve the token from PDV
 
-        SavePDVUserDTO savePDVUserDTO = SavePDVUserDTO.builder()
-            .fiscalCode(id.replace(FISCAL_CODE_PREFIX, "")).build();
+        SavePDVUserDTO savePDVUserDTO = SavePDVUserDTO.fromAttributeDtoList(attributeDTOList);
 
         try {
           ssmConnectorUtilsImpl.getParameter(PDV_API_KEY_PREFIX + clientId).ifPresentOrElse(

--- a/src/oneid/oneid-ecs-core/src/main/resources/application.properties
+++ b/src/oneid/oneid-ecs-core/src/main/resources/application.properties
@@ -67,4 +67,7 @@ quarkus.quinoa.package-manager-install.yarn-version=1.22.22
 quarkus.quinoa.enable-spa-routing=true
 quarkus.quinoa.ui-root-path=/
 #endregion
+# region Quarkus Rest Client for PDV
+# Base URL for the PagoPA Personal Data Vault (PDV) API
+quarkus.rest-client.pdv-api.url=${PDV_BASE_URL:https://api.dev.pdv.pagopa.it}
 #endregion

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/MockClientProducer.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/MockClientProducer.java
@@ -34,6 +34,10 @@ public class MockClientProducer extends ClientProducer {
         new Client("testIsRequiredSameIdpTrue", "test", "test", Set.of("foo.bar"), Set.of("test"),
             AuthLevel.L2, 0, 0, true, 0,
             "test", "test", "test", true, "test", false, null, false, false, false));
+    clients.add(
+        new Client("testPairwiseTrue", "test", "test", Set.of("foo.bar"), Set.of("test"),
+            AuthLevel.L2, 0, 0, true, 0,
+            "test", "test", "test", false, "test", false, null, false, false, true));
     clients.forEach(client -> map.put(client.getClientId(), client));
 
     return map;

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/OIDCServiceImplTest.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/OIDCServiceImplTest.java
@@ -20,7 +20,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import it.pagopa.oneid.common.connector.ClientConnectorImpl;
 import it.pagopa.oneid.common.model.dto.SecretDTO;
-import it.pagopa.oneid.common.utils.SSMConnectorUtilsUtilsImpl;
+import it.pagopa.oneid.common.utils.SSMConnectorUtilsImpl;
 import it.pagopa.oneid.connector.KMSConnectorImpl;
 import it.pagopa.oneid.connector.PDVApiClient;
 import it.pagopa.oneid.exception.InvalidClientException;
@@ -68,7 +68,7 @@ public class OIDCServiceImplTest {
   PDVApiClient pdvApiClientMock;
 
   @InjectMock
-  SSMConnectorUtilsUtilsImpl ssmConnectorUtilsImplMock;
+  SSMConnectorUtilsImpl ssmConnectorUtilsImplMock;
 
   private static String getPublicKeyPEM() {
     String key = """


### PR DESCRIPTION
<!-- You can choose the type of PR (Bug Fix, Refactor, Feature etc.) -->

### What type of PR is this?

- [ ] 🔨 Refactor
- [x] ✨ Feature
- [ ] ⛑️ Bug Fix
- [ ] 🚀 Optimization
- [ ] 📄 Documentation Update
- [ ] ⚠️ Breaking change [ℹ️](## 'Fix or feature that would cause existing functionality to not work as expected')

<!-- You can list all changes included in the PR -->

### List of Changes

- Added PDV integration to retrieve the Product related `namespaced token` of the fiscalNumber' SAMLResponse and update the PDV User Registry with the SPID/CIE obtained data. 
The functionality is activated via a `pairwise` flag onto the Client data registered inside `ClientRegistrations` table (`true` for pairwise enabling, `false `otherwise).
The API Call to PDV is made using the Product PDV API Key which is stored inside a SecureString parameter with the subsequent format for key retrieval: `/pdv/{clientId}`. This ensures the correct namespace assignment in PDV records.
The resulting JWT when pairwise is enabled will contain a `pairwise` claim, i.e.

```
{
  "sub": "_9754d2ac2b4e89040fa372d1742eb02e",
  "aud": "bxMiPVktuZ5lBNbZYJ3ODosXL57ltrLp7BgyOkw-0v4",
  "pairwise": "7a90176e-19c3-4089-aa74-4fec0077936a",
  "iss": "https://dev.oneid.pagopa.it",
  "spidCode": "SPID-008",
  "exp": 1757063727,
  "iat": 1757063667,
  "nonce": "d8d04b186f164099aba76adee2d1f010",
  "fiscalNumber": "TINIT-FLPCPT69A65Z336P",
  "sameIdp": true
}
```

Any errors during the PDV API Call (API Key retrieval, timeouts, temporary errors) won't stop the authentication flow and only warning and error logs will be printed for troubleshooting.


<!-- You can list all Jira task/bug included in the PR -->

### Related Task

- OI-435

<!-- You can specify how you tested the tasks in the pr -->

### How Has This Been Tested?

- Local tests
- Unit tests
- Cloud tests (dev)
