### PR TITLE
fix(oneid): stabilize local Docker Compose bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,19 +47,47 @@ Then
 *This will specifically run both backend and frontend*
 
 #### Configuration and mock data
-In `src/oneid/docker_mock/` folder are present some useful data to configure and use One Identity correctly. Of course **all certificates and secret are for demo purpose**.
-Firstly copy `.env.example` in `.env` and fill the required information.
+`src/oneid/docker_mock/` contains the mock data used by the local Docker Compose stack. All certificates and secrets in this directory are demo-only.
 
-In the other hand it is available a more handy mode which will starts all needed services to have a full One Identity instance using `docker-compose`. More details in next chapter.
+Remember to configure GitHub Packages access for the `it.pagopa.maven:depcheck` plugin in `src/oneid/settings.xml`:
+
+```xml
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                              https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <servers>
+		<server>
+			<id>github</id>
+      <username>YOUR_GITHUB_USERNAME</username>
+      <password>YOUR_GITHUB_TOKEN</password>
+    </server>
+  </servers>
+</settings>
+```
+
+The token only needs `read:packages` scope for local development.
+
+Before starting the stack, create `src/oneid/docker_mock/.env` for `dummy-client`:
+
+```shell
+cp src/oneid/docker_mock/.env.example src/oneid/docker_mock/.env
+```
+
+`src/oneid/docker_mock/.env.example` contains working demo credentials for local development, but you can customize them as needed.
 
 ## Start composing
+Run Docker Compose from `src/oneid`, because the compose file and the bind-mounted `docker_mock` assets are resolved from that directory:
+
 ```shell
+cd src/oneid
 docker compose up
 ```
 
 Some are having problems running compose as plugin, we'd recommend, in those cases, to switch on `docker-compose` classic syntax, as follow:
 
 ```shell
+cd src/oneid
 docker-compose up
 ```
 

--- a/src/oneid/docker-compose.yaml
+++ b/src/oneid/docker-compose.yaml
@@ -40,7 +40,22 @@ services:
       AWS_SECRET_ACCESS_KEY: "DUMMYEXAMPLEKEY"
     command:
       - |
-        sleep 3
+        echo "[dynamo-import] waiting for dynamodb-local..."
+        for i in $$(seq 1 60); do
+          if aws dynamodb list-tables --endpoint-url http://dynamodb-local:8000 --region eu-south-1 >/dev/null 2>&1; then
+            echo "[dynamo-import] dynamodb-local ready"
+            break
+          fi
+          sleep 1
+        done
+        echo "[dynamo-import] waiting for aws-local-ssm..."
+        for i in $$(seq 1 60); do
+          if aws ssm describe-parameters --endpoint http://aws-local-ssm:4566 --region eu-south-1 >/dev/null 2>&1; then
+            echo "[dynamo-import] aws-local-ssm ready"
+            break
+          fi
+          sleep 1
+        done
         aws dynamodb create-table --table-name ClientRegistrations --attribute-definitions AttributeName=clientId,AttributeType=S --key-schema AttributeName=clientId,KeyType=HASH --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5 --endpoint-url http://dynamodb-local:8000 --region eu-south-1
         aws dynamodb create-table --table-name Sessions --attribute-definitions AttributeName=samlRequestID,AttributeType=S AttributeName=recordType,AttributeType=S AttributeName=code,AttributeType=S --key-schema AttributeName=samlRequestID,KeyType=HASH AttributeName=recordType,KeyType=RANGE --global-secondary-indexes file:///home/aws/gsi_code.json --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5 --endpoint-url http://dynamodb-local:8000 --region eu-south-1
         aws dynamodb create-table --table-name IDPMetadata --attribute-definitions AttributeName=entityID,AttributeType=S AttributeName=pointer,AttributeType=S --key-schema AttributeName=entityID,KeyType=HASH AttributeName=pointer,KeyType=RANGE --global-secondary-indexes file:///home/aws/gsi_pointer.json --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5 --endpoint-url http://dynamodb-local:8000 --region eu-south-1
@@ -108,6 +123,7 @@ services:
       QUARKUS_SSM_DEVSERVICES_ENABLED: "false"
       QUARKUS_SSM_ENDPOINT_OVERRIDE: "http://aws-local-ssm:4566"
       QUARKUS_DYNAMODB_ENDPOINT_OVERRIDE: "http://dynamodb-local:8000"
+      SERVICE_METADATA_BUCKET_NAME: "local-metadata-bucket"
   oneid-lambda-client-registration:
     build:
       context: ./

--- a/src/oneid/docker_mock/.env.example
+++ b/src/oneid/docker_mock/.env.example
@@ -1,2 +1,2 @@
-client_id=xxx
-client_secret=yyy
+client_id=fM2Ki8PDGjazPFubNtv03FpJZ21CYimrS6-client_1
+client_secret=iB7QoTLouHD6szYS3sB7Ehjs7KClXnCki4kL4DBC3zc


### PR DESCRIPTION
 ### What type of PR is this?
 
 - [ ] 🔨 Refactor
 - [ ] ✨ Feature
 - [x] ⛑️ Bug Fix
 - [ ] 🚀 Optimization
 - [ ] 📄 Documentation Update
 - [ ] ⚠️ Breaking change [ℹ️](## 'Fix or feature that would cause existing functionality to not work as expected')
 
 ### List of Changes
 
 - replace the fixed `sleep` in `src/oneid/docker-compose.yaml` with readiness checks for `dynamodb-local` and `aws-local-ssm` before importing mock data
 - add `SERVICE_METADATA_BUCKET_NAME` to the local compose environment so the local stack can start with the expected metadata bucket configuration
 - provide working demo values in `src/oneid/docker_mock/.env.example` for faster local bootstrap
 - add `src/oneid/settings.xml` configuration and document the GitHub Packages setup needed for local development in `README.md`
 - **Risk:** low, scoped to local development bootstrap and setup documentation
 - **Rollback:** revert this PR to restore the previous compose startup flow and sample local configuration
 
 ### Related Task
 
 - N/A
 
 ### Does this PR need a Changeset?
 
 A changeset is a description of changes that should be included in the changelog and release notes. 
 If your PR includes significant changes that must be versioned, run `yarn changeset` from the root of the repo and select `oneidentity` plus any other affected package in order 
to create a changeset.
 
 - [ ] 🦋 I have added a changeset by running `yarn changeset`
 - [x] ❌ This PR doesn't require a changeset (e.g., documentation, config changes)
 
 ### How Has This Been Tested?
 
 - `cd src/oneid && docker compose up`
 
 ### Screenshots (if appropriate)
 
 - N/A