### PR TITLE
feat: Implement support for spid minors

### DIFF
--- a/.changeset/slow-apes-invent.md
+++ b/.changeset/slow-apes-invent.md
@@ -1,0 +1,11 @@
+---
+"oneid-lambda-client-registration": minor
+"oneid-lambda-client-manager": minor
+"oneid-ecs-internal-idp": minor
+"oi-control-panel": minor
+"oneid-ecs-core": minor
+"oneid-common": minor
+"oneidentity": minor
+---
+
+implement support for spid minors

--- a/src/oneid/oneid-common/connector/src/test/java/it/pagopa/oneid/common/connector/ClientConnectorImplTest.java
+++ b/src/oneid/oneid-common/connector/src/test/java/it/pagopa/oneid/common/connector/ClientConnectorImplTest.java
@@ -112,7 +112,7 @@ class ClientConnectorImplTest {
     ClientExtended clientExtended = new ClientExtended(clientId, userId, friendlyName, callbackURI,
         requestedParameters, authLevel, acsIndex, attributeIndex, isActive, secret, salt,
         clientIdIssuedAt, logoUri, policyUri, tosURi, isRequiredSameIdp, "", false, null, false,
-        false, false
+        false, false, null, null
     );
 
     Executable executable = () -> clientConnectorImpl.saveClientIfNotExists(clientExtended);
@@ -274,7 +274,7 @@ class ClientConnectorImplTest {
           callbackURI,
           requestedParameters, authLevel, acsIndex, attributeIndex, isActive, secret, salt,
           clientIdIssuedAt, logoUri, policyUri, tosURi, isRequiredSameIdp, "", false, null, false,
-          false, false
+          false, false, null, null
       );
 
       clientConnectorImpl.saveClientIfNotExists(clientExtended);

--- a/src/oneid/oneid-common/model/src/main/java/it/pagopa/oneid/common/model/Client.java
+++ b/src/oneid/oneid-common/model/src/main/java/it/pagopa/oneid/common/model/Client.java
@@ -79,6 +79,8 @@ public class Client {
   private boolean spidMinors;
   private boolean spidProfessionals;
   private boolean pairwise;
+  private Integer minAge;
+  private Integer maxAge;
 
   public record LocalizedContent(@NotEmpty String title, @NotEmpty String description,
                                  String docUri, String supportAddress, String cookieUri) {

--- a/src/oneid/oneid-common/model/src/main/java/it/pagopa/oneid/common/model/ClientExtended.java
+++ b/src/oneid/oneid-common/model/src/main/java/it/pagopa/oneid/common/model/ClientExtended.java
@@ -38,11 +38,11 @@ public class ClientExtended extends Client {
       String secret, String salt, long clientIdIssuedAt, String logoUri, String policyUri,
       String tosURi, boolean requiredSameIdp, String a11yUri, boolean backButtonEnabled,
       Map<String, Map<String, LocalizedContent>> localizedContentMap, boolean spidMinors,
-      boolean spidProfessionals, boolean pairwise) {
+      boolean spidProfessionals, boolean pairwise, Integer minAge, Integer maxAge) {
     super(clientId, userId, friendlyName, callbackURI, requestedParameters, authLevel, acsIndex,
         attributeIndex, isActive, clientIdIssuedAt, logoUri, policyUri, tosURi, requiredSameIdp,
         a11yUri, backButtonEnabled, localizedContentMap, spidMinors, spidProfessionals,
-        pairwise);
+        pairwise, minAge, maxAge);
     this.secret = secret;
     this.salt = salt;
   }
@@ -55,7 +55,8 @@ public class ClientExtended extends Client {
         client.getClientIdIssuedAt(), client.getLogoUri(), client.getPolicyUri(),
         client.getTosUri(), client.isRequiredSameIdp(), client.getA11yUri(),
         client.isBackButtonEnabled(), client.getLocalizedContentMap(), client.isSpidMinors(),
-        client.isSpidProfessionals(), client.isPairwise());
+        client.isSpidProfessionals(), client.isPairwise(), client.getMinAge(),
+        client.getMaxAge());
     this.secret = secret;
     this.salt = salt;
   }

--- a/src/oneid/oneid-common/model/src/main/java/it/pagopa/oneid/common/model/exception/enums/ErrorCode.java
+++ b/src/oneid/oneid-common/model/src/main/java/it/pagopa/oneid/common/model/exception/enums/ErrorCode.java
@@ -153,6 +153,7 @@ public enum ErrorCode {
       "Destination not found"),
   IDP_ERROR_DESTINATION_MISMATCH(FeErrorCode.FE_IDP_ERROR.getFeErrorCode(), "Destination mismatch"),
   CLIENT_UTILS_ERROR("CLIENT_UTILS_ERROR", "Error during Client credentials initialization"),
+  CLIENT_SPID_MINORS_ERROR("CLIENT_SPID_MINORS_ERROR", "minAge is required when spidMinors is true"),
   CLIENT_REGISTRATION_SERVICE_ERROR("CLIENT_REGISTRATION_SERVICE_ERROR",
       "Error during ClientRegistrationService method"),
   USER_ID_MISMATCH_ERROR("USER_ID_MISMATCH_ERROR", "Error during check of userId");

--- a/src/oneid/oneid-common/utils/src/main/java/it/pagopa/oneid/common/utils/SAMLUtilsConstants.java
+++ b/src/oneid/oneid-common/utils/src/main/java/it/pagopa/oneid/common/utils/SAMLUtilsConstants.java
@@ -21,5 +21,8 @@ public class SAMLUtilsConstants {
   public static String NAME_FORMAT = "urn:oasis:names:tc:SAML:2.0:attrname-format:basic";
   public static String MUNICIPALITY = "H501";
   public static String SPID_AGGREGATOR = "aggregator";
+  public static String LOCAL_NAME_AGE_LIMIT = "AgeLimit";
+  public static String LOCAL_NAME_MIN_AGE = "MinAge";
+  public static String LOCAL_NAME_MAX_AGE = "MaxAge";
   
 }

--- a/src/oneid/oneid-control-panel/src/components/ToggleSection.tsx
+++ b/src/oneid/oneid-control-panel/src/components/ToggleSection.tsx
@@ -1,0 +1,40 @@
+import { ReactNode } from 'react';
+import { Divider, FormControlLabel, FormGroup, Switch } from '@mui/material';
+import FieldWithInfo from './FieldWithInfo';
+
+type ToggleSectionProps = {
+  name: string;
+  label: string;
+  checked: boolean;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  tooltipText: ReactNode;
+  withDivider?: boolean;
+};
+
+const ToggleSection = ({
+  name,
+  label,
+  checked,
+  onChange,
+  tooltipText,
+  withDivider = false,
+}: ToggleSectionProps) => (
+  <FormGroup sx={{ mt: 2, mb: 1 }}>
+    {withDivider && <Divider sx={{ mb: 3 }} />}
+    <FieldWithInfo tooltipText={tooltipText} placement="top">
+      <FormControlLabel
+        control={
+          <Switch
+            sx={{ mr: 2, ml: 1 }}
+            name={name}
+            checked={checked}
+            onChange={onChange}
+          />
+        }
+        label={label}
+      />
+    </FieldWithInfo>
+  </FormGroup>
+);
+
+export default ToggleSection;

--- a/src/oneid/oneid-control-panel/src/components/TooltipContent.tsx
+++ b/src/oneid/oneid-control-panel/src/components/TooltipContent.tsx
@@ -1,0 +1,25 @@
+import { Link } from '@mui/material';
+import { tooltipLinkSx } from '../utils/styles';
+
+type TooltipContentProps = {
+  text: string;
+  infoUrl: string;
+};
+
+const TooltipContentWithLink = ({ text, infoUrl }: TooltipContentProps) => (
+  <span>
+    {text}
+    <br />
+    More info can be found{' '}
+    <Link
+      href={infoUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      sx={tooltipLinkSx}
+    >
+      here
+    </Link>
+  </span>
+);
+
+export default TooltipContentWithLink;

--- a/src/oneid/oneid-control-panel/src/components/UserTable.tsx
+++ b/src/oneid/oneid-control-panel/src/components/UserTable.tsx
@@ -214,18 +214,18 @@ const UserTable = ({ users, onDelete, onEdit }: Props) => {
                                     ([attrKey]) => attrKey
                                   ),
                                   ([attrKey, attrValue]) => (
-                                    <Chip
-                                      sx={{ mr: 1, mb: 1 }}
-                                      key={attrKey}
-                                      label={
-                                        <>
-                                          <strong>{attrKey}:</strong>{' '}
-                                          {attrValue}
-                                        </>
-                                      }
-                                      variant="outlined"
-                                      size="small"
-                                    />
+                                    <Box key={attrKey} sx={{ mb: 1 }}>
+                                      <Chip
+                                        label={
+                                          <>
+                                            <strong>{attrKey}:</strong>{' '}
+                                            {attrValue}
+                                          </>
+                                        }
+                                        variant="outlined"
+                                        size="small"
+                                      />
+                                    </Box>
                                   )
                                 )}
                               </>

--- a/src/oneid/oneid-control-panel/src/components/UserTable.tsx
+++ b/src/oneid/oneid-control-panel/src/components/UserTable.tsx
@@ -11,6 +11,7 @@ import {
   Typography,
   TablePagination,
   TableSortLabel,
+  Chip,
 } from '@mui/material';
 import {
   KeyboardArrowDown,
@@ -193,27 +194,41 @@ const UserTable = ({ users, onDelete, onEdit }: Props) => {
                           unmountOnExit
                         >
                           <Box margin={2}>
-                            <Typography variant="subtitle1">
+                            {user.age !== undefined && (
+                              <Box sx={{ mb: 3 }}>
+                                <Typography variant="subtitle1" sx={{ mb: 1 }}>
+                                  User Details
+                                </Typography>
+                                <strong>Age: </strong> {user.age}
+                              </Box>
+                            )}
+                            <Typography variant="subtitle1" sx={{ mb: 1 }}>
                               SAML Attributes
                             </Typography>
                             {user.samlAttributes &&
                             !isEmpty(user.samlAttributes) ? (
-                              <ul>
+                              <>
                                 {map(
                                   sortBy(
                                     Object.entries(user.samlAttributes || {}),
                                     ([attrKey]) => attrKey
                                   ),
                                   ([attrKey, attrValue]) => (
-                                    <li
+                                    <Chip
+                                      sx={{ mr: 1, mb: 1 }}
                                       key={attrKey}
-                                      style={{ marginBottom: '6px' }}
-                                    >
-                                      <strong>{attrKey}:</strong> {attrValue}
-                                    </li>
+                                      label={
+                                        <>
+                                          <strong>{attrKey}:</strong>{' '}
+                                          {attrValue}
+                                        </>
+                                      }
+                                      variant="outlined"
+                                      size="small"
+                                    />
                                   )
                                 )}
-                              </ul>
+                              </>
                             ) : (
                               <Typography variant="body2" color="textSecondary">
                                 No attributes

--- a/src/oneid/oneid-control-panel/src/pages/Dashboard/Dashboard.test.tsx
+++ b/src/oneid/oneid-control-panel/src/pages/Dashboard/Dashboard.test.tsx
@@ -436,3 +436,109 @@ describe('Dashboard UI', () => {
     spy.mockRestore();
   });
 });
+
+describe('Dashboard SPID Minors', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const fillRequiredFields = () => {
+    const nameInput = screen.getByLabelText(/Client Name/i);
+    fireEvent.change(nameInput, { target: { value: 'Test Client' } });
+
+    const redirectUrisInput = screen.getByLabelText(/Redirect URIs/i);
+    fireEvent.change(redirectUrisInput, {
+      target: { value: 'https://example.com/callback' },
+    });
+
+    const spidSelect = screen.getByLabelText(/SPID Level/i);
+    fireEvent.mouseDown(spidSelect);
+    fireEvent.click(screen.getByText('Level L2'));
+
+    const samlSelect = screen.getByLabelText(/SAML Attributes/i);
+    fireEvent.mouseDown(samlSelect);
+    fireEvent.click(screen.getByText('fiscalNumber'));
+  };
+
+  it('renders the SPID Minors toggle initially unchecked', () => {
+    render(<Dashboard />, { wrapper: createWrapper() });
+
+    const toggle = screen.getByLabelText(/SPID Minors/i);
+    expect(toggle).not.toBeChecked();
+  });
+
+  it('does not show Min Age / Max Age fields when SPID Minors is disabled', () => {
+    render(<Dashboard />, { wrapper: createWrapper() });
+
+    expect(screen.queryByLabelText(/Min Age/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Max Age/i)).not.toBeInTheDocument();
+  });
+
+  it('shows Min Age and Max Age fields when SPID Minors is enabled', () => {
+    render(<Dashboard />, { wrapper: createWrapper() });
+
+    const toggle = screen.getByLabelText(/SPID Minors/i);
+    fireEvent.click(toggle);
+
+    expect(screen.getByLabelText(/Min Age/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Max Age/i)).toBeInTheDocument();
+  });
+
+  it('disables the submit button when SPID Minors is enabled but Min Age is empty', () => {
+    render(<Dashboard />, { wrapper: createWrapper() });
+
+    fillRequiredFields();
+
+    const toggle = screen.getByLabelText(/SPID Minors/i);
+    fireEvent.click(toggle);
+
+    const submitButton = screen.getByTestId('submit-button');
+    expect(submitButton).toBeDisabled();
+  });
+
+  it('enables the submit button when SPID Minors is enabled and Min Age is filled', async () => {
+    render(<Dashboard />, { wrapper: createWrapper() });
+
+    fillRequiredFields();
+
+    const toggle = screen.getByLabelText(/SPID Minors/i);
+    fireEvent.click(toggle);
+
+    const minAgeInput = screen.getByLabelText(/Min Age/i);
+    fireEvent.change(minAgeInput, { target: { value: '10' } });
+
+    const submitButton = screen.getByTestId('submit-button');
+    await waitFor(() => expect(submitButton).not.toBeDisabled());
+  });
+
+  it('hides Min Age and Max Age fields when SPID Minors is toggled off', () => {
+    render(<Dashboard />, { wrapper: createWrapper() });
+
+    const toggle = screen.getByLabelText(/SPID Minors/i);
+    fireEvent.click(toggle);
+
+    expect(screen.getByLabelText(/Min Age/i)).toBeInTheDocument();
+
+    fireEvent.click(toggle);
+
+    expect(screen.queryByLabelText(/Min Age/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Max Age/i)).not.toBeInTheDocument();
+  });
+
+  it('shows the SPID Minors tooltip with the RFC link', async () => {
+    render(<Dashboard />, { wrapper: createWrapper() });
+
+    const infoButtons = screen.getAllByTestId('info-icon');
+    // SPID Minors is the last info icon
+    const spidMinorsInfoIcon = infoButtons[infoButtons.length - 1];
+    fireEvent.mouseOver(spidMinorsInfoIcon);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /SPID Minors allows the service to authenticate minor users/i
+        )
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/oneid/oneid-control-panel/src/pages/Dashboard/Dashboard.tsx
+++ b/src/oneid/oneid-control-panel/src/pages/Dashboard/Dashboard.tsx
@@ -7,17 +7,12 @@ import {
   Select,
   MenuItem,
   FormControl,
-  FormGroup,
   InputLabel,
   OutlinedInput,
   CircularProgress,
   Alert,
   Chip,
   FormHelperText,
-  FormControlLabel,
-  Switch,
-  Link,
-  Divider,
 } from '@mui/material';
 import {
   SpidLevel,
@@ -42,8 +37,8 @@ import SaveIcon from '@mui/icons-material/Save';
 import AddIcon from '@mui/icons-material/Add';
 import { PageContainer } from '../../components/PageContainer';
 import { ContentBox } from '../../components/ContentBox';
-import FieldWithInfo from '../../components/FieldWithInfo';
-import { tooltipLinkSx } from '../../utils/styles';
+import ToggleSection from '../../components/ToggleSection';
+import TooltipContentWithLink from '../../components/TooltipContent';
 import ConfirmDialog from '../../components/ConfirmDialog';
 
 export const Dashboard = () => {
@@ -466,76 +461,32 @@ export const Dashboard = () => {
             }
           />
 
-          <FormGroup sx={{ mt: 2, mb: 1 }}>
-            <FieldWithInfo
-              tooltipText={
-                <span>
-                  Same IDP is a function that will return a custom request
-                  indicating whether the user has logged in using the same IDP
-                  as the previous time.
-                  <br />
-                  More info can be found{' '}
-                  <Link
-                    href="https://pagopa.atlassian.net/wiki/spaces/OI/pages/1560477700/RFC+OI-004+Check+last+used+IDP+-+OTP"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    sx={tooltipLinkSx}
-                  >
-                    here
-                  </Link>
-                </span>
-              }
-              placement="top"
-            >
-              <FormControlLabel
-                control={
-                  <Switch
-                    sx={{ mr: 2, ml: 1 }}
-                    name="requiredSameIdp"
-                    checked={formData?.requiredSameIdp || false}
-                    onChange={handleChange('requiredSameIdp')}
-                  />
-                }
-                label="Required Same IDP"
+          <ToggleSection
+            name="requiredSameIdp"
+            label="Required Same IDP"
+            checked={formData?.requiredSameIdp || false}
+            onChange={handleChange('requiredSameIdp')}
+            tooltipText={
+              <TooltipContentWithLink
+                text="Same IDP is a function that will return a custom request indicating whether the user has logged in using the same IDP as the previous time."
+                infoUrl="https://pagopa.atlassian.net/wiki/spaces/OI/pages/1560477700/RFC+OI-004+Check+last+used+IDP+-+OTP"
               />
-            </FieldWithInfo>
-          </FormGroup>
+            }
+          />
 
-          <FormGroup sx={{ mt: 2, mb: 1 }}>
-            <Divider sx={{ mb: 3 }} />
-            <FieldWithInfo
-              tooltipText={
-                <span>
-                  Pairwise pseudonymous is an OIDC object used to replace the
-                  subject identifier. One Identity will leverage on PDV Building
-                  block to calculate or obtain it.
-                  <br />
-                  More info can be found{' '}
-                  <Link
-                    href="https://pagopa.atlassian.net/wiki/spaces/OI/pages/2101936152/OI+-+Integrazione+PDV"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    sx={tooltipLinkSx}
-                  >
-                    here
-                  </Link>
-                </span>
-              }
-              placement="top"
-            >
-              <FormControlLabel
-                control={
-                  <Switch
-                    sx={{ mr: 2, ml: 1 }}
-                    name="pairWise"
-                    checked={formData?.pairwise || false}
-                    onChange={handleChange('pairwise')}
-                  />
-                }
-                label="Pairwise Enabled"
+          <ToggleSection
+            name="pairWise"
+            label="Pairwise Enabled"
+            checked={formData?.pairwise || false}
+            onChange={handleChange('pairwise')}
+            withDivider
+            tooltipText={
+              <TooltipContentWithLink
+                text="Pairwise pseudonymous is an OIDC object used to replace the subject identifier. One Identity will leverage on PDV Building block to calculate or obtain it."
+                infoUrl="https://pagopa.atlassian.net/wiki/spaces/OI/pages/2101936152/OI+-+Integrazione+PDV"
               />
-            </FieldWithInfo>
-          </FormGroup>
+            }
+          />
           {formData?.pairwise && (
             <Box
               sx={{
@@ -630,60 +581,38 @@ export const Dashboard = () => {
             </Box>
           )}
 
-          <FormGroup sx={{ mt: 2, mb: 1 }}>
-            <Divider sx={{ mb: 3 }} />
-            <FieldWithInfo
-              tooltipText={
-                <span>
-                  SPID Minors allows the service to authenticate minor users
-                  (under 18). When enabled, you can define an allowed age range
-                  for minor authentication.
-                  <br />
-                  More info can be found{' '}
-                  <Link
-                    href="https://pagopa.atlassian.net/wiki/spaces/OI/pages/2965078170/RFC+OI-016+-+Supporto+SPID+per+minori"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    sx={tooltipLinkSx}
-                  >
-                    here
-                  </Link>
-                </span>
+          <ToggleSection
+            name="spidMinors"
+            label="SPID Minors"
+            checked={formData?.spidMinors || false}
+            onChange={(e) => {
+              const checked = e.target.checked;
+              setFormData((prev) => ({
+                ...prev,
+                spidMinors: checked,
+                ...(!checked && {
+                  minAge: undefined,
+                  maxAge: undefined,
+                }),
+              }));
+              if (!checked) {
+                // reset minage and maxage errors
+                setErrorUi((prev) => {
+                  if (!prev) return prev;
+                  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                  const { minAge: _, maxAge: __, ...rest } = prev;
+                  return rest as ClientErrors;
+                });
               }
-              placement="top"
-            >
-              <FormControlLabel
-                control={
-                  <Switch
-                    sx={{ mr: 2, ml: 1 }}
-                    name="spidMinors"
-                    checked={formData?.spidMinors || false}
-                    onChange={(e) => {
-                      const checked = e.target.checked;
-                      setFormData((prev) => ({
-                        ...prev,
-                        spidMinors: checked,
-                        ...(!checked && {
-                          minAge: undefined,
-                          maxAge: undefined,
-                        }),
-                      }));
-                      if (!checked) {
-                        // reset minage and maxage errors
-                        setErrorUi((prev) => {
-                          if (!prev) return prev;
-                          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                          const { minAge: _, maxAge: __, ...rest } = prev;
-                          return rest as ClientErrors;
-                        });
-                      }
-                    }}
-                  />
-                }
-                label="SPID Minors"
+            }}
+            withDivider
+            tooltipText={
+              <TooltipContentWithLink
+                text="SPID Minors allows the service to authenticate minor users (under 18). When enabled, you can define an allowed age range for minor authentication."
+                infoUrl="https://pagopa.atlassian.net/wiki/spaces/OI/pages/2965078170/RFC+OI-016+-+Supporto+SPID+per+minori"
               />
-            </FieldWithInfo>
-          </FormGroup>
+            }
+          />
           {formData?.spidMinors && (
             <Box
               sx={{

--- a/src/oneid/oneid-control-panel/src/pages/Dashboard/Dashboard.tsx
+++ b/src/oneid/oneid-control-panel/src/pages/Dashboard/Dashboard.tsx
@@ -570,6 +570,7 @@ export const Dashboard = () => {
                     <Select
                       labelId="pairwise-select-label"
                       name="pairwiseOption"
+                      required
                       value={pairWiseData?.apiKeyId || ''}
                       label="Plan Name"
                       onChange={(e) =>
@@ -595,6 +596,7 @@ export const Dashboard = () => {
                   </FormControl>
                   <TextField
                     fullWidth
+                    required
                     label="Key value"
                     name="pairwiseValue"
                     value={pairWiseData?.apiKeyValue || ''}

--- a/src/oneid/oneid-control-panel/src/pages/Dashboard/Dashboard.tsx
+++ b/src/oneid/oneid-control-panel/src/pages/Dashboard/Dashboard.tsx
@@ -304,6 +304,9 @@ export const Dashboard = () => {
     validationIsValid === true ||
     fetchedClientData?.pairwise === true;
 
+  const checkEnableSpidMinors = (): boolean =>
+    !!formData?.spidMinors && !formData?.minAge;
+
   return (
     <PageContainer>
       {fetchError && fetchError.message !== 'Client not found' && (
@@ -626,6 +629,106 @@ export const Dashboard = () => {
               )}
             </Box>
           )}
+
+          <FormGroup sx={{ mt: 2, mb: 1 }}>
+            <Divider sx={{ mb: 3 }} />
+            <FieldWithInfo
+              tooltipText={
+                <span>
+                  SPID Minors allows the service to authenticate minor users
+                  (under 18). When enabled, you can define an allowed age range
+                  for minor authentication.
+                  <br />
+                  More info can be found{' '}
+                  <Link
+                    href="https://pagopa.atlassian.net/wiki/spaces/OI/pages/2965078170/RFC+OI-016+-+Supporto+SPID+per+minori"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    sx={tooltipLinkSx}
+                  >
+                    here
+                  </Link>
+                </span>
+              }
+              placement="top"
+            >
+              <FormControlLabel
+                control={
+                  <Switch
+                    sx={{ mr: 2, ml: 1 }}
+                    name="spidMinors"
+                    checked={formData?.spidMinors || false}
+                    onChange={(e) => {
+                      const checked = e.target.checked;
+                      setFormData((prev) => ({
+                        ...prev,
+                        spidMinors: checked,
+                        ...(!checked && {
+                          minAge: undefined,
+                          maxAge: undefined,
+                        }),
+                      }));
+                      if (!checked) {
+                        // reset minage and maxage errors
+                        setErrorUi((prev) => {
+                          if (!prev) return prev;
+                          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                          const { minAge: _, maxAge: __, ...rest } = prev;
+                          return rest as ClientErrors;
+                        });
+                      }
+                    }}
+                  />
+                }
+                label="SPID Minors"
+              />
+            </FieldWithInfo>
+          </FormGroup>
+          {formData?.spidMinors && (
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'row',
+                gap: 2,
+                mt: 2,
+                width: '100%',
+              }}
+            >
+              <TextField
+                label="Min Age"
+                fullWidth
+                required
+                type="number"
+                inputProps={{ min: 1, max: 99 }}
+                value={formData?.minAge ?? ''}
+                onChange={(e) => {
+                  const val = e.target.value;
+                  setFormData((prev) => ({
+                    ...prev,
+                    minAge: val === '' ? undefined : parseInt(val, 10),
+                  }));
+                }}
+                error={!!(errorUi as ClientErrors)?.minAge?._errors}
+                helperText={(errorUi as ClientErrors)?.minAge?._errors}
+              />
+              <TextField
+                label="Max Age"
+                fullWidth
+                type="number"
+                inputProps={{ min: 1, max: 99 }}
+                value={formData?.maxAge ?? ''}
+                onChange={(e) => {
+                  const val = e.target.value;
+                  setFormData((prev) => ({
+                    ...prev,
+                    maxAge: val === '' ? undefined : parseInt(val, 10),
+                  }));
+                }}
+                error={!!(errorUi as ClientErrors)?.maxAge?._errors}
+                helperText={(errorUi as ClientErrors)?.maxAge?._errors}
+              />
+            </Box>
+          )}
         </ContentBox>
 
         <Box>
@@ -637,6 +740,7 @@ export const Dashboard = () => {
             data-testid="submit-button"
             disabled={
               !checkEnableSaveUpdateClientPairwiseBased() ||
+              checkEnableSpidMinors() ||
               isUpdating ||
               !isFormValid()
             }

--- a/src/oneid/oneid-control-panel/src/pages/Users/ManageUsers/AddOrUpdateUser.test.tsx
+++ b/src/oneid/oneid-control-panel/src/pages/Users/ManageUsers/AddOrUpdateUser.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import type * as ReactRouterDom from 'react-router-dom';
-import { vi, describe, it, beforeEach, expect, Mock } from 'vitest';
+import { vi, describe, it, beforeEach, afterEach, expect, Mock } from 'vitest';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AddOrUpdateUser } from './AddOrUpdateUser';
@@ -110,6 +110,10 @@ describe('AddOrUpdateUser', () => {
       isSuccess: false,
       isPending: false,
     };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('calls createClientUsersMutation when form is valid and submitted', async () => {
@@ -282,14 +286,98 @@ describe('AddOrUpdateUser', () => {
   });
 
   it('should not submit if form is invalid', async () => {
-    const user = userEvent.setup();
     render(<AddOrUpdateUser />, { wrapper: createWrapper() });
 
     const submitBtn = screen.getByTestId(submitBtnId);
-    await user.click(submitBtn);
+    expect(submitBtn).toBeDisabled();
+
+    fireEvent.click(submitBtn);
 
     await waitFor(() => {
       expect(mockCreate).not.toHaveBeenCalled();
     });
+  });
+
+  it('renders the Age field', () => {
+    render(<AddOrUpdateUser />, { wrapper: createWrapper() });
+
+    expect(screen.getByLabelText(/Age/i)).toBeInTheDocument();
+  });
+
+  it('submits without age when age is not filled (age is optional)', async () => {
+    const user = userEvent.setup();
+    render(<AddOrUpdateUser />, { wrapper: createWrapper() });
+
+    await user.type(screen.getByLabelText(/Username/i), 'newuser');
+    await user.type(
+      screen.getByLabelText(/Password/i, { selector: 'input' }),
+      'password123'
+    );
+
+    const selectButton = screen.getByRole('button', { name: /saml/i });
+    await user.click(selectButton);
+    const attributeInput = await screen.findByLabelText(/Value for name/i);
+    await user.type(attributeInput, 'name');
+
+    const submitBtn = screen.getByTestId(submitBtnId);
+    expect(submitBtn).not.toBeDisabled();
+    await user.click(submitBtn);
+
+    await waitFor(() => {
+      expect(mockCreate).toHaveBeenCalledWith({
+        data: expect.not.objectContaining({ age: expect.anything() }),
+      });
+    });
+  });
+
+  it('includes age in the mutation payload when provided', async () => {
+    const user = userEvent.setup();
+    render(<AddOrUpdateUser />, { wrapper: createWrapper() });
+
+    await user.type(screen.getByLabelText(/Username/i), 'newuser');
+    await user.type(
+      screen.getByLabelText(/Password/i, { selector: 'input' }),
+      'password123'
+    );
+
+    const selectButton = screen.getByRole('button', { name: /saml/i });
+    await user.click(selectButton);
+    const attributeInput = await screen.findByLabelText(/Value for name/i);
+    await user.type(attributeInput, 'name');
+
+    const ageInput = screen.getByLabelText(/Age/i);
+    await user.type(ageInput, '17');
+
+    const submitBtn = screen.getByTestId(submitBtnId);
+    expect(submitBtn).not.toBeDisabled();
+    await user.click(submitBtn);
+
+    await waitFor(() => {
+      expect(mockCreate).toHaveBeenCalledWith({
+        data: expect.objectContaining({ age: 17 }),
+      });
+    });
+  });
+
+  it('disables submit when age is out of range (e.g. 0)', async () => {
+    const user = userEvent.setup();
+    render(<AddOrUpdateUser />, { wrapper: createWrapper() });
+
+    await user.type(screen.getByLabelText(/Username/i), 'newuser');
+    await user.type(
+      screen.getByLabelText(/Password/i, { selector: 'input' }),
+      'password123'
+    );
+
+    const selectButton = screen.getByRole('button', { name: /saml/i });
+    await user.click(selectButton);
+    const attributeInput = await screen.findByLabelText(/Value for name/i);
+    await user.type(attributeInput, 'name');
+
+    const ageInput = screen.getByLabelText(/Age/i);
+    await user.type(ageInput, '0');
+
+    const submitBtn = screen.getByTestId(submitBtnId);
+    expect(submitBtn).toBeDisabled();
   });
 });

--- a/src/oneid/oneid-control-panel/src/pages/Users/ManageUsers/AddOrUpdateUser.tsx
+++ b/src/oneid/oneid-control-panel/src/pages/Users/ManageUsers/AddOrUpdateUser.tsx
@@ -258,6 +258,24 @@ export const AddOrUpdateUser = () => {
               }}
             />
           </SamlAttributesSelectInput>
+
+          <TextField
+            fullWidth
+            label="Age"
+            type="number"
+            inputProps={{ min: 1, max: 99 }}
+            value={formData?.age ?? ''}
+            onChange={(e) => {
+              const val = e.target.value;
+              setFormData((prev) => ({
+                ...prev,
+                age: val === '' ? undefined : parseInt(val, 10),
+              }));
+            }}
+            margin="normal"
+            error={!!(errorUi as UserErrors)?.age?._errors}
+            helperText={(errorUi as UserErrors)?.age?._errors}
+          />
         </ContentBox>
 
         <Button

--- a/src/oneid/oneid-control-panel/src/types/api.ts
+++ b/src/oneid/oneid-control-panel/src/types/api.ts
@@ -229,6 +229,7 @@ export const idpUserSchema = z.object({
   username: z.string().trim().min(1),
   password: z.string().trim().min(1),
   samlAttributes: z.record(SamlAttributeSchema, z.string().trim().min(1)),
+  age: z.number().int().min(1).max(99).optional(),
 });
 export const idpUserListSchema = z.object({
   users: z.array(idpUserSchema),

--- a/src/oneid/oneid-control-panel/src/types/api.ts
+++ b/src/oneid/oneid-control-panel/src/types/api.ts
@@ -169,8 +169,8 @@ export const clientSchema = z
     requiredSameIdp: z.boolean().optional(),
     // feature flags
     spidMinors: z.boolean().optional(),
-    minAge: z.number().int().min(1).max(99).optional(),
-    maxAge: z.number().int().min(1).max(99).optional(),
+    minAge: z.number().int().min(1).max(99).nullish(),
+    maxAge: z.number().int().min(1).max(99).nullish(),
     spidProfessionals: z.boolean().optional(),
     pairwise: z.boolean().optional(),
     // customize

--- a/src/oneid/oneid-control-panel/src/types/api.ts
+++ b/src/oneid/oneid-control-panel/src/types/api.ts
@@ -1,3 +1,4 @@
+import isNil from 'lodash/isNil';
 import { z } from 'zod';
 
 export type LoginResponse = {
@@ -151,31 +152,56 @@ const ThemeSchema = z.object({
 const ThemeLocalizedSchema = z.record(LanguagesSchema, ThemeSchema);
 
 // TODO: check and eventually remove optional from required fields
-export const clientSchema = z.object({
-  userId: z.string().optional(),
-  clientId: z.string().optional(),
-  clientSecret: z.string().nullish(),
-  clientIdIssuedAt: z.number().optional(),
-  clientSecretExpiresAt: z.number().optional(),
-  clientName: z.string().optional(),
-  policyUri: httpsUrlSchema.nullish(),
-  tosUri: httpsUrlSchema.nullish(),
-  redirectUris: z.array(httpsUrlSchema).min(1),
-  samlRequestedAttributes: SamlAttributeArraySchema.min(1),
-  logoUri: httpsUrlSchema.nullish(),
-  defaultAcrValues: SpidLevelArraySchema.min(1),
-  requiredSameIdp: z.boolean().optional(),
-  // feature flags
-  spidMinors: z.boolean().optional(),
-  spidProfessionals: z.boolean().optional(),
-  pairwise: z.boolean().optional(),
-  // customize
-  a11yUri: httpsUrlSchema.nullish(),
-  backButtonEnabled: z.boolean().optional().default(false),
-  localizedContentMap: z
-    .record(z.union([z.literal('default'), z.string()]), ThemeLocalizedSchema)
-    .nullish(),
-});
+export const clientSchema = z
+  .object({
+    userId: z.string().optional(),
+    clientId: z.string().optional(),
+    clientSecret: z.string().nullish(),
+    clientIdIssuedAt: z.number().optional(),
+    clientSecretExpiresAt: z.number().optional(),
+    clientName: z.string().optional(),
+    policyUri: httpsUrlSchema.nullish(),
+    tosUri: httpsUrlSchema.nullish(),
+    redirectUris: z.array(httpsUrlSchema).min(1),
+    samlRequestedAttributes: SamlAttributeArraySchema.min(1),
+    logoUri: httpsUrlSchema.nullish(),
+    defaultAcrValues: SpidLevelArraySchema.min(1),
+    requiredSameIdp: z.boolean().optional(),
+    // feature flags
+    spidMinors: z.boolean().optional(),
+    minAge: z.number().int().min(1).max(99).optional(),
+    maxAge: z.number().int().min(1).max(99).optional(),
+    spidProfessionals: z.boolean().optional(),
+    pairwise: z.boolean().optional(),
+    // customize
+    a11yUri: httpsUrlSchema.nullish(),
+    backButtonEnabled: z.boolean().optional().default(false),
+    localizedContentMap: z
+      .record(z.union([z.literal('default'), z.string()]), ThemeLocalizedSchema)
+      .nullish(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.spidMinors) {
+      if (isNil(data.minAge)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Min Age is required when SPID Minors is enabled',
+          path: ['minAge'],
+        });
+      }
+      if (
+        !isNil(data.maxAge) &&
+        !isNil(data.minAge) &&
+        data.maxAge < data.minAge
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Max Age must be greater than or equal to Min Age',
+          path: ['maxAge'],
+        });
+      }
+    }
+  });
 
 export const planSchema = z.object({
   id: z.string().trim().min(1),

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SAMLService.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SAMLService.java
@@ -15,7 +15,7 @@ import org.opensaml.saml.saml2.core.Response;
 public interface SAMLService {
 
   AuthnRequest buildAuthnRequest(String idpSSOEndpoint, int assertionConsumerServiceIndex,
-      int attributeConsumingServiceIndex, String spidLevel)
+      int attributeConsumingServiceIndex, String spidLevel, Integer minAge, Integer maxAge)
       throws OneIdentityException;
 
   void validateSAMLResponse(Response SAMLResponse, String entityID, Set<String> requestedAttributes,

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SAMLServiceImpl.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/SAMLServiceImpl.java
@@ -478,19 +478,21 @@ public class SAMLServiceImpl implements SAMLService {
 
   @Override
   public AuthnRequest buildAuthnRequest(String idpSSOEndpoint, int assertionConsumerServiceIndex,
-      int attributeConsumingServiceIndex, String authLevel) throws OneIdentityException {
+      int attributeConsumingServiceIndex, String authLevel, Integer minAge, Integer maxAge)
+      throws OneIdentityException {
     return this.buildAuthnRequest(idpSSOEndpoint, assertionConsumerServiceIndex,
-        attributeConsumingServiceIndex, "", authLevel);
+        attributeConsumingServiceIndex, "", authLevel, minAge, maxAge);
   }
 
   private AuthnRequest buildAuthnRequest(String idpSSOEndpoint, int assertionConsumerServiceIndex,
-      int attributeConsumingServiceIndex, String purpose, String authLevel)
+      int attributeConsumingServiceIndex, String purpose, String authLevel,
+      Integer minAge, Integer maxAge)
       throws OneIdentityException {
     validateParameters(idpSSOEndpoint, assertionConsumerServiceIndex,
         attributeConsumingServiceIndex);
 
     AuthnRequest authnRequest = createAuthnRequest(idpSSOEndpoint, assertionConsumerServiceIndex,
-        attributeConsumingServiceIndex, authLevel);
+        attributeConsumingServiceIndex, authLevel, minAge, maxAge);
     try {
       Signature signature = samlUtils.buildSignature(authnRequest);
       authnRequest.setSignature(signature);
@@ -503,7 +505,7 @@ public class SAMLServiceImpl implements SAMLService {
   }
 
   private AuthnRequest createAuthnRequest(String idpSSOEndpoint, int assertionConsumerServiceIndex,
-      int attributeConsumingServiceIndex, String authLevel) {
+      int attributeConsumingServiceIndex, String authLevel, Integer minAge, Integer maxAge) {
     AuthnRequest authnRequest = samlUtils.buildSAMLObject(AuthnRequest.class);
     authnRequest.setIssueInstant(Instant.now());
     authnRequest.setForceAuthn(true);
@@ -514,6 +516,11 @@ public class SAMLServiceImpl implements SAMLService {
     authnRequest.setDestination(idpSSOEndpoint);
     authnRequest.setAssertionConsumerServiceIndex(assertionConsumerServiceIndex);
     authnRequest.setAttributeConsumingServiceIndex(attributeConsumingServiceIndex);
+
+    if (minAge != null && maxAge != null) {
+      authnRequest.setExtensions(samlUtils.buildAgeLimitExtensions(minAge, maxAge));
+    }
+
     return authnRequest;
   }
 

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/utils/SAMLUtilsExtendedCore.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/service/utils/SAMLUtilsExtendedCore.java
@@ -8,6 +8,7 @@ import it.pagopa.oneid.common.model.exception.OneIdentityException;
 import it.pagopa.oneid.common.model.exception.SAMLUtilsException;
 import it.pagopa.oneid.common.model.exception.enums.ErrorCode;
 import it.pagopa.oneid.common.utils.SAMLUtils;
+import it.pagopa.oneid.common.utils.SAMLUtilsConstants;
 import it.pagopa.oneid.common.utils.logging.CustomLogging;
 import it.pagopa.oneid.connector.CloudWatchConnectorImpl;
 import it.pagopa.oneid.exception.GenericAuthnRequestCreationException;
@@ -48,7 +49,9 @@ import org.opensaml.core.xml.io.Marshaller;
 import org.opensaml.core.xml.io.MarshallerFactory;
 import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.core.xml.io.UnmarshallingException;
+import org.opensaml.core.xml.schema.XSAny;
 import org.opensaml.core.xml.schema.XSString;
+import org.opensaml.core.xml.schema.impl.XSAnyBuilder;
 import org.opensaml.core.xml.schema.impl.XSAnyImpl;
 import org.opensaml.core.xml.util.XMLObjectSupport;
 import org.opensaml.saml.saml2.core.Assertion;
@@ -56,6 +59,7 @@ import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.core.AuthnContextClassRef;
 import org.opensaml.saml.saml2.core.AuthnContextComparisonTypeEnumeration;
 import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.Extensions;
 import org.opensaml.saml.saml2.core.Issuer;
 import org.opensaml.saml.saml2.core.NameIDPolicy;
 import org.opensaml.saml.saml2.core.NameIDType;
@@ -107,6 +111,33 @@ public class SAMLUtilsExtendedCore extends SAMLUtils {
 
   public RequestedAuthnContext buildRequestedAuthnContext(String spidLevel) {
     return createRequestedAuthnContext(spidLevel, AuthnContextComparisonTypeEnumeration.MINIMUM);
+  }
+
+  public Extensions buildAgeLimitExtensions(int minAge, int maxAge) {
+    Extensions extensions = buildSAMLObject(Extensions.class);
+
+    XSAny ageLimit = new XSAnyBuilder().buildObject(
+        SAMLUtilsConstants.NAMESPACE_URI_SPID,
+        SAMLUtilsConstants.LOCAL_NAME_AGE_LIMIT,
+        SAMLUtilsConstants.NAMESPACE_PREFIX_SPID);
+
+    XSAny minAgeElement = new XSAnyBuilder().buildObject(
+        SAMLUtilsConstants.NAMESPACE_URI_SPID,
+        SAMLUtilsConstants.LOCAL_NAME_MIN_AGE,
+        SAMLUtilsConstants.NAMESPACE_PREFIX_SPID);
+    minAgeElement.setTextContent(String.valueOf(minAge));
+
+    XSAny maxAgeElement = new XSAnyBuilder().buildObject(
+        SAMLUtilsConstants.NAMESPACE_URI_SPID,
+        SAMLUtilsConstants.LOCAL_NAME_MAX_AGE,
+        SAMLUtilsConstants.NAMESPACE_PREFIX_SPID);
+    maxAgeElement.setTextContent(String.valueOf(maxAge));
+
+    ageLimit.getUnknownXMLObjects().add(minAgeElement);
+    ageLimit.getUnknownXMLObjects().add(maxAgeElement);
+    extensions.getUnknownXMLObjects().add(ageLimit);
+
+    return extensions;
   }
 
   public Optional<List<AttributeDTO>> getAttributeDTOListFromAssertion(Assertion assertion) {

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/OIDCController.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/OIDCController.java
@@ -197,7 +197,7 @@ public class OIDCController {
       authnRequest = samlServiceImpl.buildAuthnRequest(idpSSOEndpoint, client.getAcsIndex(),
           client.getAttributeIndex(), client.getAuthLevel().getValue(),
           client.isSpidMinors() ? client.getMinAge() : null,
-          client.isSpidMinors() ? client.getMaxAge() : null);
+          client.isSpidMinors() ? (client.getMaxAge() != null ? client.getMaxAge() : 99) : null); // In case maxAge is not set, the upper limit is set to 99 as defined by AGID documentation
     } catch (GenericAuthnRequestCreationException | IDPSSOEndpointNotFoundException |
              OneIdentityException e) {
       Log.error("error building authorization request: " + e.getMessage());

--- a/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/OIDCController.java
+++ b/src/oneid/oneid-ecs-core/src/main/java/it/pagopa/oneid/web/controller/OIDCController.java
@@ -195,7 +195,9 @@ public class OIDCController {
     AuthnRequest authnRequest = null;
     try {
       authnRequest = samlServiceImpl.buildAuthnRequest(idpSSOEndpoint, client.getAcsIndex(),
-          client.getAttributeIndex(), client.getAuthLevel().getValue());
+          client.getAttributeIndex(), client.getAuthLevel().getValue(),
+          client.isSpidMinors() ? client.getMinAge() : null,
+          client.isSpidMinors() ? client.getMaxAge() : null);
     } catch (GenericAuthnRequestCreationException | IDPSSOEndpointNotFoundException |
              OneIdentityException e) {
       Log.error("error building authorization request: " + e.getMessage());

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/MockClientProducer.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/MockClientProducer.java
@@ -25,19 +25,23 @@ public class MockClientProducer extends ClientProducer {
     clients.add(
         new Client("test", "test", "test", Set.of("foo.bar"), Set.of("test"), AuthLevel.L2, 0, 0,
             true, 0,
-            "test", "test", "test", true, "test", false, null, false, false, false));
+            "test", "test", "test", true, "test", false, null, false, false, false,
+            null, null));
     clients.add(
         new Client("testIsRequiredSameIdpFalse", "test", "test", Set.of("foo.bar"), Set.of("test"),
             AuthLevel.L2, 0, 0, true, 0,
-            "test", "test", "test", false, "test", false, null, false, false, false));
+            "test", "test", "test", false, "test", false, null, false, false, false,
+            null, null));
     clients.add(
         new Client("testIsRequiredSameIdpTrue", "test", "test", Set.of("foo.bar"), Set.of("test"),
             AuthLevel.L2, 0, 0, true, 0,
-            "test", "test", "test", true, "test", false, null, false, false, false));
+            "test", "test", "test", true, "test", false, null, false, false, false,
+            null, null));
     clients.add(
         new Client("testPairwiseTrue", "test", "test", Set.of("foo.bar"), Set.of("test"),
             AuthLevel.L2, 0, 0, true, 0,
-            "test", "test", "test", false, "test", false, null, false, false, true));
+            "test", "test", "test", false, "test", false, null, false, false, true,
+            null, null));
     clients.forEach(client -> map.put(client.getClientId(), client));
 
     return map;

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/SAMLServiceImplTest.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/service/SAMLServiceImplTest.java
@@ -150,6 +150,8 @@ import static it.pagopa.oneid.model.Base64SAMLResponses.VERSION_NOT_02_SAML_RESP
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -245,9 +247,39 @@ public class SAMLServiceImplTest {
     String authLevel = "foobar";
 
     AuthnRequest authnRequest = samlServiceImpl.buildAuthnRequest(idpId,
-        assertionConsumerServiceIndex, attributeConsumingServiceIndex, authLevel);
+        assertionConsumerServiceIndex, attributeConsumingServiceIndex, authLevel, null, null);
 
     assertFalse(authnRequest.getID().isEmpty());
+  }
+
+  @Test
+  void buildAuthnRequest_withAgeLimit() throws OneIdentityException {
+    // given
+    String idpId = "dummy";
+    int assertionConsumerServiceIndex = 0;
+    int attributeConsumingServiceIndex = 0;
+    String authLevel = "foobar";
+
+    AuthnRequest authnRequest = samlServiceImpl.buildAuthnRequest(idpId,
+        assertionConsumerServiceIndex, attributeConsumingServiceIndex, authLevel, 14, 99);
+
+    assertFalse(authnRequest.getID().isEmpty());
+    assertNotNull(authnRequest.getExtensions());
+  }
+
+  @Test
+  void buildAuthnRequest_withoutAgeLimit() throws OneIdentityException {
+    // given
+    String idpId = "dummy";
+    int assertionConsumerServiceIndex = 0;
+    int attributeConsumingServiceIndex = 0;
+    String authLevel = "foobar";
+
+    AuthnRequest authnRequest = samlServiceImpl.buildAuthnRequest(idpId,
+        assertionConsumerServiceIndex, attributeConsumingServiceIndex, authLevel, null, null);
+
+    assertFalse(authnRequest.getID().isEmpty());
+    assertNull(authnRequest.getExtensions());
   }
 
   @Test
@@ -259,7 +291,7 @@ public class SAMLServiceImplTest {
     String authLevel = "foobar";
 
     assertThrows(OneIdentityException.class, () -> samlServiceImpl.buildAuthnRequest(idpId,
-        assertionConsumerServiceIndex, attributeConsumingServiceIndex, authLevel));
+        assertionConsumerServiceIndex, attributeConsumingServiceIndex, authLevel, null, null));
   }
 
   @Test
@@ -271,7 +303,7 @@ public class SAMLServiceImplTest {
     String authLevel = "foobar";
 
     assertThrows(OneIdentityException.class, () -> samlServiceImpl.buildAuthnRequest(idpId,
-        assertionConsumerServiceIndex, attributeConsumingServiceIndex, authLevel));
+        assertionConsumerServiceIndex, attributeConsumingServiceIndex, authLevel, null, null));
   }
 
   @Test
@@ -283,7 +315,7 @@ public class SAMLServiceImplTest {
     String authLevel = "foobar";
 
     assertThrows(OneIdentityException.class, () -> samlServiceImpl.buildAuthnRequest(idpId,
-        assertionConsumerServiceIndex, attributeConsumingServiceIndex, authLevel));
+        assertionConsumerServiceIndex, attributeConsumingServiceIndex, authLevel, null, null));
   }
 
   @Test
@@ -298,7 +330,7 @@ public class SAMLServiceImplTest {
     // then
 
     Executable executable = () -> samlServiceImpl.buildAuthnRequest(idpId,
-        assertionConsumerServiceIndex, attributeConsumingServiceIndex, authLevel);
+        assertionConsumerServiceIndex, attributeConsumingServiceIndex, authLevel, null, null);
     assertThrows(GenericAuthnRequestCreationException.class, executable);
   }
 

--- a/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/web/controller/OIDCControllerTest.java
+++ b/src/oneid/oneid-ecs-core/src/test/java/it/pagopa/oneid/web/controller/OIDCControllerTest.java
@@ -141,7 +141,7 @@ class OIDCControllerTest {
 
     Mockito.when(
             samlServiceImpl.buildAuthnRequest(Mockito.anyString(), Mockito.anyInt(), Mockito.anyInt(),
-                Mockito.anyString()))
+                Mockito.anyString(), Mockito.any(), Mockito.any()))
         .thenReturn(authnRequest);
 
     Mockito.when(oidcServiceImpl.getStringValue(Mockito.any())).thenReturn("test");
@@ -309,7 +309,7 @@ class OIDCControllerTest {
 
     Mockito.when(
             samlServiceImpl.buildAuthnRequest(Mockito.anyString(), Mockito.anyInt(), Mockito.anyInt(),
-                Mockito.anyString()))
+                Mockito.anyString(), Mockito.any(), Mockito.any()))
         .thenReturn(authnRequest);
 
     Mockito.when(oidcServiceImpl.getStringValue(Mockito.any())).thenReturn("test");
@@ -448,7 +448,7 @@ class OIDCControllerTest {
     // Mock "6. Create SAML Authn Request using SAMLServiceImpl" with error
     Mockito.when(
             samlServiceImpl.buildAuthnRequest(Mockito.anyString(), Mockito.anyInt(), Mockito.anyInt(),
-                Mockito.anyString()))
+                Mockito.anyString(), Mockito.any(), Mockito.any()))
         .thenThrow(OneIdentityException.class);
 
     //then
@@ -499,7 +499,7 @@ class OIDCControllerTest {
 
     Mockito.when(
             samlServiceImpl.buildAuthnRequest(Mockito.anyString(), Mockito.anyInt(), Mockito.anyInt(),
-                Mockito.anyString()))
+                Mockito.anyString(), Mockito.any(), Mockito.any()))
         .thenReturn(authnRequest);
 
     Mockito.when(oidcServiceImpl.getStringValue(Mockito.any())).thenReturn("test");
@@ -565,7 +565,7 @@ class OIDCControllerTest {
 
     Mockito.when(
             samlServiceImpl.buildAuthnRequest(Mockito.anyString(), Mockito.anyInt(), Mockito.anyInt(),
-                Mockito.anyString()))
+                Mockito.anyString(), Mockito.any(), Mockito.any()))
         .thenReturn(authnRequest);
 
     Mockito.when(oidcServiceImpl.getStringValue(Mockito.any())).thenReturn("test");

--- a/src/oneid/oneid-ecs-internal-idp/src/main/java/it/pagopa/oneid/model/IDPInternalUser.java
+++ b/src/oneid/oneid-ecs-internal-idp/src/main/java/it/pagopa/oneid/model/IDPInternalUser.java
@@ -32,4 +32,6 @@ public class IDPInternalUser {
 
   @NotNull
   private Map<String, String> samlAttributes;
+
+  private Integer age;
 }

--- a/src/oneid/oneid-ecs-internal-idp/src/main/java/it/pagopa/oneid/model/IDPSession.java
+++ b/src/oneid/oneid-ecs-internal-idp/src/main/java/it/pagopa/oneid/model/IDPSession.java
@@ -38,4 +38,8 @@ public class IDPSession {
 
   @NotNull
   private IDPSessionStatus status;
+
+  private Integer minAge;
+
+  private Integer maxAge;
 }

--- a/src/oneid/oneid-ecs-internal-idp/src/main/java/it/pagopa/oneid/service/InternalIDPService.java
+++ b/src/oneid/oneid-ecs-internal-idp/src/main/java/it/pagopa/oneid/service/InternalIDPService.java
@@ -3,6 +3,7 @@ package it.pagopa.oneid.service;
 import it.pagopa.oneid.common.model.Client;
 import it.pagopa.oneid.common.model.exception.OneIdentityException;
 import it.pagopa.oneid.common.model.exception.SAMLUtilsException;
+import java.util.Optional;
 import java.util.Set;
 import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.saml2.core.Response;
@@ -16,7 +17,15 @@ public interface InternalIDPService {
 
   Client getClientByAttributeConsumingServiceIndex(AuthnRequest authnRequest);
 
+  Optional<int[]> extractAgeLimit(AuthnRequest authnRequest);
+
+  void verifyAge(String clientId, String username, Integer minAge, Integer maxAge)
+      throws OneIdentityException;
+
   Response createSuccessfulSamlResponse(String authnRequestId, String clientId, String username)
+      throws SAMLUtilsException;
+
+  Response createAgeVerificationFailureResponse(String authnRequestId)
       throws SAMLUtilsException;
 
   Element getElementValueFromSamlResponse(Response samlResponse);

--- a/src/oneid/oneid-ecs-internal-idp/src/main/java/it/pagopa/oneid/service/InternalIDPServiceImpl.java
+++ b/src/oneid/oneid-ecs-internal-idp/src/main/java/it/pagopa/oneid/service/InternalIDPServiceImpl.java
@@ -221,7 +221,8 @@ public class InternalIDPServiceImpl extends SAMLUtils implements InternalIDPServ
           }
         }
 
-        if (minAge != null && maxAge != null) {
+        if (minAge != null) {
+          maxAge = (maxAge != null) ? maxAge : 99;
           return Optional.of(new int[]{minAge, maxAge});
         }
       }
@@ -248,8 +249,7 @@ public class InternalIDPServiceImpl extends SAMLUtils implements InternalIDPServ
 
     if (age < minAge || (maxAge != 99 && age > maxAge)) {
       String userName = user.getSamlAttributes().getOrDefault("name", username);
-      throw new OneIdentityException(
-          "Spiacente " + userName + ", ma non hai l'età richiesta per accedere al servizio");
+      throw new OneIdentityException(userName + " doesn't have the required age for the service.");
     }
   }
 

--- a/src/oneid/oneid-ecs-internal-idp/src/main/java/it/pagopa/oneid/service/InternalIDPServiceImpl.java
+++ b/src/oneid/oneid-ecs-internal-idp/src/main/java/it/pagopa/oneid/service/InternalIDPServiceImpl.java
@@ -29,6 +29,7 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.time.Instant;
 import java.util.Base64;
+import java.util.Optional;
 import java.util.Set;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
@@ -38,10 +39,12 @@ import net.shibboleth.utilities.java.support.xml.BasicParserPool;
 import net.shibboleth.utilities.java.support.xml.XMLParserException;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.io.Marshaller;
 import org.opensaml.core.xml.io.MarshallerFactory;
 import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.core.xml.io.UnmarshallingException;
+import org.opensaml.core.xml.schema.XSAny;
 import org.opensaml.core.xml.util.XMLObjectSupport;
 import org.opensaml.saml.common.SAMLObjectContentReference;
 import org.opensaml.saml.common.SAMLVersion;
@@ -63,6 +66,7 @@ import org.opensaml.saml.saml2.core.NameIDType;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.core.Status;
 import org.opensaml.saml.saml2.core.StatusCode;
+import org.opensaml.saml.saml2.core.StatusMessage;
 import org.opensaml.saml.saml2.core.Subject;
 import org.opensaml.saml.saml2.core.SubjectConfirmation;
 import org.opensaml.saml.saml2.core.SubjectConfirmationData;
@@ -192,6 +196,63 @@ public class InternalIDPServiceImpl extends SAMLUtils implements InternalIDPServ
 
   }
 
+  @Override
+  public Optional<int[]> extractAgeLimit(AuthnRequest authnRequest) {
+    if (authnRequest.getExtensions() == null) {
+      return Optional.empty();
+    }
+
+    for (XMLObject extension : authnRequest.getExtensions().getUnknownXMLObjects()) {
+      if (SAMLUtilsConstants.LOCAL_NAME_AGE_LIMIT.equals(extension.getElementQName().getLocalPart())
+          && SAMLUtilsConstants.NAMESPACE_URI_SPID.equals(
+          extension.getElementQName().getNamespaceURI())) {
+
+        Integer minAge = null;
+        Integer maxAge = null;
+
+        for (XMLObject child : extension.getOrderedChildren()) {
+          String localPart = child.getElementQName().getLocalPart();
+          if (SAMLUtilsConstants.LOCAL_NAME_MIN_AGE.equals(localPart)
+              && child instanceof XSAny xsAny) {
+            minAge = Integer.parseInt(xsAny.getTextContent());
+          } else if (SAMLUtilsConstants.LOCAL_NAME_MAX_AGE.equals(localPart)
+              && child instanceof XSAny xsAny) {
+            maxAge = Integer.parseInt(xsAny.getTextContent());
+          }
+        }
+
+        if (minAge != null && maxAge != null) {
+          return Optional.of(new int[]{minAge, maxAge});
+        }
+      }
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public void verifyAge(String clientId, String username, Integer minAge, Integer maxAge)
+      throws OneIdentityException {
+    if (minAge == null || maxAge == null) {
+      return;
+    }
+
+    IDPInternalUser user = internalIDPUsersConnectorImpl
+        .getIDPInternalUserByUsernameAndNamespace(username, clientId)
+        .orElseThrow(() -> new OneIdentityException("User not found"));
+
+    if (user.getAge() == null) {
+      return;
+    }
+
+    int age = user.getAge();
+
+    if (age < minAge || (maxAge != 99 && age > maxAge)) {
+      String userName = user.getSamlAttributes().getOrDefault("name", username);
+      throw new OneIdentityException(
+          "Spiacente " + userName + ", ma non hai l'età richiesta per accedere al servizio");
+    }
+  }
+
 
   @Override
   public Response createSuccessfulSamlResponse(String authnRequestId,
@@ -210,6 +271,43 @@ public class InternalIDPServiceImpl extends SAMLUtils implements InternalIDPServ
 
     return buildSAMLResponse(authnRequestId, StatusCode.SUCCESS, user, requestedParameters);
 
+  }
+
+  @Override
+  public Response createAgeVerificationFailureResponse(String authnRequestId)
+      throws SAMLUtilsException {
+    Response samlResponse = buildSAMLObject(Response.class);
+
+    samlResponse.setID(generateSecureRandomId());
+    samlResponse.setVersion(SAMLVersion.VERSION_20);
+    samlResponse.setIssueInstant(Instant.now());
+    samlResponse.setInResponseTo(authnRequestId);
+    samlResponse.setDestination(ACS_ENDPOINT);
+
+    Issuer issuer = buildSAMLObject(Issuer.class);
+    issuer.setValue(ISSUER);
+    issuer.setNameQualifier(ISSUER);
+    issuer.setFormat(NameIDType.ENTITY);
+    samlResponse.setIssuer(issuer);
+
+    Status status = buildSAMLObject(Status.class);
+    StatusCode statusCode = buildSAMLObject(StatusCode.class);
+    statusCode.setValue(StatusCode.RESPONDER);
+    status.setStatusCode(statusCode);
+
+    org.opensaml.saml.saml2.core.StatusMessage statusMessage = buildSAMLObject(
+        org.opensaml.saml.saml2.core.StatusMessage.class);
+    statusMessage.setValue("AGE_VERIFICATION_FAILED");
+    status.setStatusMessage(statusMessage);
+
+    samlResponse.setStatus(status);
+
+    BasicX509Credential idpX509Credential = getIdpbasicX509Credential(ssmClient);
+    Signature signature = buildSignature(samlResponse, idpX509Credential);
+    samlResponse.setSignature(signature);
+    marshallAndSignResponse(samlResponse, signature);
+
+    return samlResponse;
   }
 
   public void validateUserInformation(String clientId, String username, String password)

--- a/src/oneid/oneid-ecs-internal-idp/src/main/java/it/pagopa/oneid/service/SessionServiceImpl.java
+++ b/src/oneid/oneid-ecs-internal-idp/src/main/java/it/pagopa/oneid/service/SessionServiceImpl.java
@@ -23,6 +23,9 @@ public class SessionServiceImpl implements SessionService {
   @Inject
   SessionConnectorImpl sessionConnectorImpl;
 
+  @Inject
+  InternalIDPServiceImpl internalIDPServiceImpl;
+
   @Override
   public void saveIDPSession(AuthnRequest authnRequest, Client client) {
     Log.debug("Start saveIDPSession for authnRequestId: " + authnRequest.getID());
@@ -41,6 +44,13 @@ public class SessionServiceImpl implements SessionService {
         .timestampStart(Instant.now().toEpochMilli())
         .timestampEnd(0)
         .build();
+
+    Optional<int[]> ageLimit = internalIDPServiceImpl.extractAgeLimit(authnRequest);
+    ageLimit.ifPresent(ages -> {
+      idpSession.setMinAge(ages[0]);
+      idpSession.setMaxAge(ages[1]);
+    });
+
     sessionConnectorImpl.saveIDPSessionIfNotExists(idpSession);
     Log.debug("End saveIDPSession for authnRequestId: " + authnRequest.getID());
   }

--- a/src/oneid/oneid-ecs-internal-idp/src/main/java/it/pagopa/oneid/web/controller/InternalIDPController.java
+++ b/src/oneid/oneid-ecs-internal-idp/src/main/java/it/pagopa/oneid/web/controller/InternalIDPController.java
@@ -72,7 +72,7 @@ public class InternalIDPController {
     TemplateInstance instance = login.data("loginAction", IDP_LOGIN_ENDPOINT)
         .data("authnRequestId", authnRequest.getID())
         .data("clientId", client.getClientId())
-        .data("clientName", client.getFriendlyName());;
+        .data("clientName", client.getFriendlyName());
 
     return Response.status(Status.OK)
         .entity(instance.render())
@@ -154,6 +154,22 @@ public class InternalIDPController {
   }
 
   private Response handleConsentGiven(IDPSession idpSession) throws SAMLUtilsException {
+
+    // Verify age limit if present in the session
+    if (idpSession.getMinAge() != null && idpSession.getMaxAge() != null) {
+      try {
+        internalIDPServiceImpl.verifyAge(idpSession.getClientId(), idpSession.getUsername(),
+            idpSession.getMinAge(), idpSession.getMaxAge());
+      } catch (OneIdentityException e) {
+        // Age verification failed - return failure SAML Response to SP
+        return Response.status(Status.OK)
+            .entity(error.data("errorMessage",
+                "Spiacente " + idpSession.getUsername() + ", ma non hai l’età richiesta da "
+                    + idpSession.getClientId() + " per accedere al servizio"))
+            .type(MediaType.TEXT_HTML)
+            .build();
+      }
+    }
 
     // Create a successful SAML Response based on the AuthnRequest
 

--- a/src/oneid/oneid-ecs-internal-idp/src/main/java/it/pagopa/oneid/web/controller/InternalIDPController.java
+++ b/src/oneid/oneid-ecs-internal-idp/src/main/java/it/pagopa/oneid/web/controller/InternalIDPController.java
@@ -164,8 +164,7 @@ public class InternalIDPController {
         // Age verification failed - return failure SAML Response to SP
         return Response.status(Status.OK)
             .entity(error.data("errorMessage",
-                "Spiacente " + idpSession.getUsername() + ", ma non hai l’età richiesta da "
-                    + idpSession.getClientId() + " per accedere al servizio"))
+                "Spiacente " + idpSession.getUsername() + ", ma non hai l’età richiesta per accedere al servizio"))
             .type(MediaType.TEXT_HTML)
             .build();
       }

--- a/src/oneid/oneid-ecs-internal-idp/src/test/java/it/pagopa/oneid/service/InternalIDPServiceImplTest.java
+++ b/src/oneid/oneid-ecs-internal-idp/src/test/java/it/pagopa/oneid/service/InternalIDPServiceImplTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import it.pagopa.oneid.common.model.exception.OneIdentityException;
 import it.pagopa.oneid.common.utils.SAMLUtilsConstants;
 import it.pagopa.oneid.connector.InternalIDPUsersConnectorImpl;
@@ -25,6 +26,7 @@ import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.saml2.core.Extensions;
 
 @QuarkusTest
+@TestProfile(InternalIDPServiceTestProfile.class)
 class InternalIDPServiceImplTest {
 
   @Inject
@@ -198,8 +200,8 @@ class InternalIDPServiceImplTest {
             .getIDPInternalUserByUsernameAndNamespace("testUser", "clientId"))
         .thenReturn(Optional.of(user));
 
-    OneIdentityException ex = assertThrows(OneIdentityException.class,
+    //in case of a already existing user with missing age, the method should not throw an exception and allow the flow to continue
+    assertDoesNotThrow(
         () -> internalIDPServiceImpl.verifyAge("clientId", "testUser", 14, 99));
-    assertEquals("User age attribute is missing", ex.getMessage());
   }
 }

--- a/src/oneid/oneid-ecs-internal-idp/src/test/java/it/pagopa/oneid/service/InternalIDPServiceImplTest.java
+++ b/src/oneid/oneid-ecs-internal-idp/src/test/java/it/pagopa/oneid/service/InternalIDPServiceImplTest.java
@@ -1,8 +1,37 @@
 package it.pagopa.oneid.service;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import it.pagopa.oneid.common.model.exception.OneIdentityException;
+import it.pagopa.oneid.common.utils.SAMLUtilsConstants;
+import it.pagopa.oneid.connector.InternalIDPUsersConnectorImpl;
+import it.pagopa.oneid.model.IDPInternalUser;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.xml.namespace.QName;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.core.xml.schema.XSAny;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.Extensions;
 
+@QuarkusTest
 class InternalIDPServiceImplTest {
+
+  @Inject
+  InternalIDPServiceImpl internalIDPServiceImpl;
+
+  @InjectMock
+  InternalIDPUsersConnectorImpl internalIDPUsersConnectorImpl;
 
   @Test
   void getAuthnRequestFromString() {
@@ -14,5 +43,163 @@ class InternalIDPServiceImplTest {
 
   @Test
   void getClientByAttributeConsumingServiceIndex() {
+  }
+
+  @Test
+  @DisplayName("given_authnRequest_without_extensions_when_extractAgeLimit_then_empty")
+  void extractAgeLimit_noExtensions() {
+    AuthnRequest authnRequest = Mockito.mock(AuthnRequest.class);
+    Mockito.when(authnRequest.getExtensions()).thenReturn(null);
+
+    Optional<int[]> result = internalIDPServiceImpl.extractAgeLimit(authnRequest);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  @DisplayName("given_authnRequest_with_age_limit_extensions_when_extractAgeLimit_then_returns_values")
+  void extractAgeLimit_withAgeLimit() {
+    AuthnRequest authnRequest = Mockito.mock(AuthnRequest.class);
+    Extensions extensions = Mockito.mock(Extensions.class);
+
+    XSAny minAgeElement = Mockito.mock(XSAny.class);
+    Mockito.when(minAgeElement.getElementQName()).thenReturn(
+        new QName(SAMLUtilsConstants.NAMESPACE_URI_SPID, SAMLUtilsConstants.LOCAL_NAME_MIN_AGE));
+    Mockito.when(minAgeElement.getTextContent()).thenReturn("14");
+
+    XSAny maxAgeElement = Mockito.mock(XSAny.class);
+    Mockito.when(maxAgeElement.getElementQName()).thenReturn(
+        new QName(SAMLUtilsConstants.NAMESPACE_URI_SPID, SAMLUtilsConstants.LOCAL_NAME_MAX_AGE));
+    Mockito.when(maxAgeElement.getTextContent()).thenReturn("99");
+
+    XMLObject ageLimitElement = Mockito.mock(XMLObject.class);
+    Mockito.when(ageLimitElement.getElementQName()).thenReturn(
+        new QName(SAMLUtilsConstants.NAMESPACE_URI_SPID, SAMLUtilsConstants.LOCAL_NAME_AGE_LIMIT));
+    Mockito.when(ageLimitElement.getOrderedChildren())
+        .thenReturn(List.of(minAgeElement, maxAgeElement));
+
+    Mockito.when(extensions.getUnknownXMLObjects()).thenReturn(List.of(ageLimitElement));
+    Mockito.when(authnRequest.getExtensions()).thenReturn(extensions);
+
+    Optional<int[]> result = internalIDPServiceImpl.extractAgeLimit(authnRequest);
+
+    assertTrue(result.isPresent());
+    assertArrayEquals(new int[]{14, 99}, result.get());
+  }
+
+  @Test
+  @DisplayName("given_null_age_params_when_verifyAge_then_no_exception")
+  void verifyAge_nullParams() {
+    assertDoesNotThrow(
+        () -> internalIDPServiceImpl.verifyAge("clientId", "username", null, null));
+  }
+
+  @Test
+  @DisplayName("given_user_within_age_range_when_verifyAge_then_no_exception")
+  void verifyAge_withinRange() {
+    IDPInternalUser user = IDPInternalUser.builder()
+        .username("testUser")
+        .namespace("clientId")
+        .password("pass")
+        .samlAttributes(Map.of("name", "Mario"))
+        .age(20)
+        .build();
+
+    Mockito.when(internalIDPUsersConnectorImpl
+            .getIDPInternalUserByUsernameAndNamespace("testUser", "clientId"))
+        .thenReturn(Optional.of(user));
+
+    assertDoesNotThrow(
+        () -> internalIDPServiceImpl.verifyAge("clientId", "testUser", 14, 99));
+  }
+
+  @Test
+  @DisplayName("given_user_below_min_age_when_verifyAge_then_throws")
+  void verifyAge_belowMinAge() {
+    IDPInternalUser user = IDPInternalUser.builder()
+        .username("testUser")
+        .namespace("clientId")
+        .password("pass")
+        .samlAttributes(Map.of("name", "Mario"))
+        .age(10)
+        .build();
+
+    Mockito.when(internalIDPUsersConnectorImpl
+            .getIDPInternalUserByUsernameAndNamespace("testUser", "clientId"))
+        .thenReturn(Optional.of(user));
+
+    OneIdentityException ex = assertThrows(OneIdentityException.class,
+        () -> internalIDPServiceImpl.verifyAge("clientId", "testUser", 14, 99));
+    assertTrue(ex.getMessage().contains("Mario"));
+  }
+
+  @Test
+  @DisplayName("given_user_above_max_age_when_verifyAge_then_throws")
+  void verifyAge_aboveMaxAge() {
+    IDPInternalUser user = IDPInternalUser.builder()
+        .username("testUser")
+        .namespace("clientId")
+        .password("pass")
+        .samlAttributes(Map.of("name", "Luigi"))
+        .age(25)
+        .build();
+
+    Mockito.when(internalIDPUsersConnectorImpl
+            .getIDPInternalUserByUsernameAndNamespace("testUser", "clientId"))
+        .thenReturn(Optional.of(user));
+
+    OneIdentityException ex = assertThrows(OneIdentityException.class,
+        () -> internalIDPServiceImpl.verifyAge("clientId", "testUser", 14, 18));
+    assertTrue(ex.getMessage().contains("Luigi"));
+  }
+
+  @Test
+  @DisplayName("given_max_age_99_and_user_older_when_verifyAge_then_no_exception")
+  void verifyAge_maxAge99MeansNoUpperLimit() {
+    IDPInternalUser user = IDPInternalUser.builder()
+        .username("testUser")
+        .namespace("clientId")
+        .password("pass")
+        .samlAttributes(Map.of("name", "Nonna"))
+        .age(80)
+        .build();
+
+    Mockito.when(internalIDPUsersConnectorImpl
+            .getIDPInternalUserByUsernameAndNamespace("testUser", "clientId"))
+        .thenReturn(Optional.of(user));
+
+    assertDoesNotThrow(
+        () -> internalIDPServiceImpl.verifyAge("clientId", "testUser", 14, 99));
+  }
+
+  @Test
+  @DisplayName("given_user_not_found_when_verifyAge_then_throws")
+  void verifyAge_userNotFound() {
+    Mockito.when(internalIDPUsersConnectorImpl
+            .getIDPInternalUserByUsernameAndNamespace("testUser", "clientId"))
+        .thenReturn(Optional.empty());
+
+    OneIdentityException ex = assertThrows(OneIdentityException.class,
+        () -> internalIDPServiceImpl.verifyAge("clientId", "testUser", 14, 99));
+    assertEquals("User not found", ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("given_user_without_age_when_verifyAge_then_throws")
+  void verifyAge_missingAge() {
+    IDPInternalUser user = IDPInternalUser.builder()
+        .username("testUser")
+        .namespace("clientId")
+        .password("pass")
+        .samlAttributes(Map.of("name", "Mario"))
+        .build();
+
+    Mockito.when(internalIDPUsersConnectorImpl
+            .getIDPInternalUserByUsernameAndNamespace("testUser", "clientId"))
+        .thenReturn(Optional.of(user));
+
+    OneIdentityException ex = assertThrows(OneIdentityException.class,
+        () -> internalIDPServiceImpl.verifyAge("clientId", "testUser", 14, 99));
+    assertEquals("User age attribute is missing", ex.getMessage());
   }
 }

--- a/src/oneid/oneid-ecs-internal-idp/src/test/java/it/pagopa/oneid/service/InternalIDPServiceTestProfile.java
+++ b/src/oneid/oneid-ecs-internal-idp/src/test/java/it/pagopa/oneid/service/InternalIDPServiceTestProfile.java
@@ -1,0 +1,12 @@
+package it.pagopa.oneid.service;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+import java.util.Set;
+
+public class InternalIDPServiceTestProfile implements QuarkusTestProfile {
+
+  @Override
+  public Set<Class<?>> getEnabledAlternatives() {
+    return Set.of(MockConfigBasicX509Credential.class);
+  }
+}

--- a/src/oneid/oneid-ecs-internal-idp/src/test/java/it/pagopa/oneid/service/MockConfigBasicX509Credential.java
+++ b/src/oneid/oneid-ecs-internal-idp/src/test/java/it/pagopa/oneid/service/MockConfigBasicX509Credential.java
@@ -1,0 +1,20 @@
+package it.pagopa.oneid.service;
+
+import it.pagopa.oneid.common.utils.config.ConfigBasicX509Credential;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.Produces;
+import org.mockito.Mockito;
+import org.opensaml.security.x509.BasicX509Credential;
+
+@Alternative
+@Dependent
+public class MockConfigBasicX509Credential extends ConfigBasicX509Credential {
+
+  @Singleton
+  @Produces
+  BasicX509Credential basicX509Credential() {
+    return Mockito.mock(BasicX509Credential.class);
+  }
+}

--- a/src/oneid/oneid-ecs-internal-idp/src/test/resources/application.properties
+++ b/src/oneid/oneid-ecs-internal-idp/src/test/resources/application.properties
@@ -1,0 +1,2 @@
+certificate_name=dummy
+key_name=dummy

--- a/src/oneid/oneid-lambda-client-manager/index.py
+++ b/src/oneid/oneid-lambda-client-manager/index.py
@@ -218,21 +218,30 @@ def create_idp_internal_user():
             "message": f"Invalid saml attribute(s): {', '.join(invalid_keys)}. Valid attributes are: {', '.join(valid_saml_attributes)}"
             }, 400
 
+        # Extract the optional age field
+        age = body.get("age")
+
+        # Build the item for DynamoDB
+        item = {
+            "username": {"S": username},
+            "namespace": {"S": client_id},
+            "password": {"S": password},
+            "samlAttributes": {
+                "M": {
+                    k: {"N": str(v)} if k == "spidLevel" else {"S": str(v)}
+                    for k, v in saml_attributes.items()
+                }
+            },
+        }
+
+        if age is not None:
+            item["age"] = {"N": str(int(age))}
+
         # Create user in Internal IDP
         response = dynamodb_client.put_item(
             TableName=os.getenv("IDP_INTERNAL_USERS_TABLE_NAME"),
             ConditionExpression="attribute_not_exists(username) AND attribute_not_exists(namespace)",
-            Item={
-                "username": {"S": username},
-                "namespace": {"S": client_id},
-                "password": {"S": password},
-                "samlAttributes": {
-                    "M": {
-                        k: {"N": str(v)} if k == "spidLevel" else {"S": str(v)}
-                        for k, v in saml_attributes.items()
-                    }
-                },
-            },
+            Item=item,
         )
         logger.info("[create_idp_internal_user]: %s", response)
 
@@ -284,18 +293,37 @@ def update_idp_internal_user(username: str):
 
         # Extract the samlAttributes from the request body
         saml_attributes = body.get("samlAttributes", {})
+        age = body.get("age")
 
-        if not saml_attributes:
-            logger.error("[update_idp_internal_user]: samlAttributes are required")
-            return {"message": "samlAttributes are required"}, 400
+        if not saml_attributes and age is None:
+            logger.error("[update_idp_internal_user]: samlAttributes or age are required")
+            return {"message": "samlAttributes or age are required"}, 400
 
         # Ensure that samlAttributes only contains valid keys
-        invalid_keys = set(saml_attributes) - valid_saml_attributes
-        if invalid_keys:
-            logger.error("[update_idp_internal_user]: Invalid saml attributes: %s", invalid_keys)
-            return {
-                "message": f"Invalid saml attribute(s): {', '.join(invalid_keys)}. Valid attributes are: {', '.join(valid_saml_attributes)}"
-            }, 400
+        if saml_attributes:
+            invalid_keys = set(saml_attributes) - valid_saml_attributes
+            if invalid_keys:
+                logger.error("[update_idp_internal_user]: Invalid saml attributes: %s", invalid_keys)
+                return {
+                    "message": f"Invalid saml attribute(s): {', '.join(invalid_keys)}. Valid attributes are: {', '.join(valid_saml_attributes)}"
+                }, 400
+
+        # Build update expression dynamically
+        update_parts = []
+        expression_values = {}
+
+        if saml_attributes:
+            update_parts.append("samlAttributes = :samlAttributes")
+            expression_values[":samlAttributes"] = {
+                "M": {
+                    k: {"N": str(v)} if k == "spidLevel" else {"S": str(v)}
+                    for k, v in saml_attributes.items()
+                }
+            }
+
+        if age is not None:
+            update_parts.append("age = :age")
+            expression_values[":age"] = {"N": str(int(age))}
 
         # Update user in Internal IDP
         response = dynamodb_client.update_item(
@@ -305,15 +333,8 @@ def update_idp_internal_user(username: str):
                 "namespace": {"S": client_id},
             },
             ConditionExpression="attribute_exists(username) AND attribute_exists(namespace)",
-            UpdateExpression="SET samlAttributes = :samlAttributes",
-            ExpressionAttributeValues={
-                ":samlAttributes": {
-                    "M": {
-                        k: {"N": str(v)} if k == "spidLevel" else {"S": str(v)}
-                        for k, v in saml_attributes.items()
-                    }
-                }
-            },
+            UpdateExpression="SET " + ", ".join(update_parts),
+            ExpressionAttributeValues=expression_values,
         )
         logger.info("[update_idp_internal_user]: %s", response)
 
@@ -451,6 +472,9 @@ def get_idp_internal_users():
                     k: v["S"] if "S" in v else v["N"]
                     for k, v in user.get("samlAttributes", {}).get("M", {}).items()
                 },
+                **({
+                    "age": int(user["age"]["N"])
+                } if "age" in user else {}),
             }
             for user in items
         ])

--- a/src/oneid/oneid-lambda-client-manager/test_index.py
+++ b/src/oneid/oneid-lambda-client-manager/test_index.py
@@ -2,8 +2,8 @@
 Unit tests for index.py
 """
 import unittest
-from unittest.mock import patch, Mock
-from index import check_client_id_exists, get_cognito_client, get_dynamodb_client
+from unittest.mock import patch, Mock, MagicMock
+from index import check_client_id_exists, get_cognito_client, get_dynamodb_client, app
 
 
 class TestCheckClientIdExists(unittest.TestCase):
@@ -74,6 +74,191 @@ class TestGetDynamoDBClient(unittest.TestCase):
         result = get_dynamodb_client("eu-south-1")
         mock_boto3_client.assert_called_once_with("dynamodb", region_name="eu-south-1")
         self.assertIsNone(result)
+
+
+class TestCreateIdpInternalUserAge(unittest.TestCase):
+    """Tests for age field in create_idp_internal_user."""
+
+    @patch("index.extract_client_id_from_connected_user", return_value="client-123")
+    @patch("index.get_user_id_from_bearer", return_value="user-123")
+    @patch("index.dynamodb_client")
+    @patch("os.getenv", return_value="test_table")
+    def test_create_user_with_age(self, mock_getenv, mock_dynamodb, mock_get_user, mock_extract):
+        mock_dynamodb.put_item.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
+
+        event = {
+            "httpMethod": "POST",
+            "path": "/client-manager/client-users",
+            "headers": {"Authorization": "Bearer dummy"},
+            "body": '{"username":"testuser","password":"pass","samlAttributes":{"name":"Mario"},"age":16}',
+            "requestContext": {"stage": "test"},
+            "resource": "/client-manager/client-users",
+        }
+
+        response = app.resolve(event, {})
+        self.assertEqual(response["statusCode"], 201)
+        call_args = mock_dynamodb.put_item.call_args
+        item = call_args[1]["Item"] if "Item" in call_args[1] else call_args.kwargs["Item"]
+        self.assertEqual(item["age"], {"N": "16"})
+
+    @patch("index.extract_client_id_from_connected_user", return_value="client-123")
+    @patch("index.get_user_id_from_bearer", return_value="user-123")
+    @patch("index.dynamodb_client")
+    @patch("os.getenv", return_value="test_table")
+    def test_create_user_without_age(self, mock_getenv, mock_dynamodb, mock_get_user, mock_extract):
+        mock_dynamodb.put_item.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
+
+        event = {
+            "httpMethod": "POST",
+            "path": "/client-manager/client-users",
+            "headers": {"Authorization": "Bearer dummy"},
+            "body": '{"username":"testuser","password":"pass","samlAttributes":{"name":"Mario"}}',
+            "requestContext": {"stage": "test"},
+            "resource": "/client-manager/client-users",
+        }
+
+        response = app.resolve(event, {})
+        self.assertEqual(response["statusCode"], 201)
+        call_args = mock_dynamodb.put_item.call_args
+        item = call_args[1]["Item"] if "Item" in call_args[1] else call_args.kwargs["Item"]
+        self.assertNotIn("age", item)
+
+
+class TestUpdateIdpInternalUserAge(unittest.TestCase):
+    """Tests for age field in update_idp_internal_user."""
+
+    @patch("index.extract_client_id_from_connected_user", return_value="client-123")
+    @patch("index.get_user_id_from_bearer", return_value="user-123")
+    @patch("index.dynamodb_client")
+    @patch("os.getenv", return_value="test_table")
+    def test_update_user_with_age_only(self, mock_getenv, mock_dynamodb, mock_get_user, mock_extract):
+        mock_dynamodb.update_item.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
+
+        event = {
+            "httpMethod": "PATCH",
+            "path": "/client-manager/client-users/testuser",
+            "headers": {"Authorization": "Bearer dummy"},
+            "body": '{"age":18}',
+            "requestContext": {"stage": "test"},
+            "resource": "/client-manager/client-users/{username}",
+            "pathParameters": {"username": "testuser"},
+        }
+
+        response = app.resolve(event, {})
+        self.assertEqual(response["statusCode"], 200)
+        call_args = mock_dynamodb.update_item.call_args
+        kwargs = call_args[1] if call_args[1] else call_args.kwargs
+        self.assertIn("age = :age", kwargs["UpdateExpression"])
+        self.assertEqual(kwargs["ExpressionAttributeValues"][":age"], {"N": "18"})
+
+    @patch("index.extract_client_id_from_connected_user", return_value="client-123")
+    @patch("index.get_user_id_from_bearer", return_value="user-123")
+    @patch("index.dynamodb_client")
+    @patch("os.getenv", return_value="test_table")
+    def test_update_user_with_age_and_saml(self, mock_getenv, mock_dynamodb, mock_get_user, mock_extract):
+        mock_dynamodb.update_item.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
+
+        event = {
+            "httpMethod": "PATCH",
+            "path": "/client-manager/client-users/testuser",
+            "headers": {"Authorization": "Bearer dummy"},
+            "body": '{"samlAttributes":{"name":"Luigi"},"age":20}',
+            "requestContext": {"stage": "test"},
+            "resource": "/client-manager/client-users/{username}",
+            "pathParameters": {"username": "testuser"},
+        }
+
+        response = app.resolve(event, {})
+        self.assertEqual(response["statusCode"], 200)
+        call_args = mock_dynamodb.update_item.call_args
+        kwargs = call_args[1] if call_args[1] else call_args.kwargs
+        self.assertIn("samlAttributes = :samlAttributes", kwargs["UpdateExpression"])
+        self.assertIn("age = :age", kwargs["UpdateExpression"])
+
+    @patch("index.extract_client_id_from_connected_user", return_value="client-123")
+    @patch("index.get_user_id_from_bearer", return_value="user-123")
+    @patch("index.dynamodb_client")
+    @patch("os.getenv", return_value="test_table")
+    def test_update_user_no_saml_no_age_returns_400(self, mock_getenv, mock_dynamodb, mock_get_user, mock_extract):
+        event = {
+            "httpMethod": "PATCH",
+            "path": "/client-manager/client-users/testuser",
+            "headers": {"Authorization": "Bearer dummy"},
+            "body": '{}',
+            "requestContext": {"stage": "test"},
+            "resource": "/client-manager/client-users/{username}",
+            "pathParameters": {"username": "testuser"},
+        }
+
+        response = app.resolve(event, {})
+        self.assertEqual(response["statusCode"], 400)
+
+
+class TestGetIdpInternalUsersAge(unittest.TestCase):
+    """Tests for age field in get_idp_internal_users."""
+
+    @patch("index.extract_client_id_from_connected_user", return_value="client-123")
+    @patch("index.get_user_id_from_bearer", return_value="user-123")
+    @patch("index.dynamodb_client")
+    @patch("os.getenv", return_value="test_table")
+    def test_get_users_includes_age(self, mock_getenv, mock_dynamodb, mock_get_user, mock_extract):
+        mock_dynamodb.query.return_value = {
+            "ResponseMetadata": {"HTTPStatusCode": 200},
+            "Items": [
+                {
+                    "username": {"S": "testuser"},
+                    "password": {"S": "pass"},
+                    "samlAttributes": {"M": {"name": {"S": "Mario"}}},
+                    "age": {"N": "16"},
+                }
+            ],
+        }
+
+        event = {
+            "httpMethod": "GET",
+            "path": "/client-manager/client-users",
+            "headers": {"Authorization": "Bearer dummy"},
+            "queryStringParameters": {"limit": "10"},
+            "requestContext": {"stage": "test"},
+            "resource": "/client-manager/client-users",
+        }
+
+        response = app.resolve(event, {})
+        self.assertEqual(response["statusCode"], 200)
+        import json
+        body = json.loads(response["body"])
+        self.assertEqual(body["users"][0]["age"], 16)
+
+    @patch("index.extract_client_id_from_connected_user", return_value="client-123")
+    @patch("index.get_user_id_from_bearer", return_value="user-123")
+    @patch("index.dynamodb_client")
+    @patch("os.getenv", return_value="test_table")
+    def test_get_users_without_age(self, mock_getenv, mock_dynamodb, mock_get_user, mock_extract):
+        mock_dynamodb.query.return_value = {
+            "ResponseMetadata": {"HTTPStatusCode": 200},
+            "Items": [
+                {
+                    "username": {"S": "testuser"},
+                    "password": {"S": "pass"},
+                    "samlAttributes": {"M": {"name": {"S": "Mario"}}},
+                }
+            ],
+        }
+
+        event = {
+            "httpMethod": "GET",
+            "path": "/client-manager/client-users",
+            "headers": {"Authorization": "Bearer dummy"},
+            "queryStringParameters": {"limit": "10"},
+            "requestContext": {"stage": "test"},
+            "resource": "/client-manager/client-users",
+        }
+
+        response = app.resolve(event, {})
+        self.assertEqual(response["statusCode"], 200)
+        import json
+        body = json.loads(response["body"])
+        self.assertNotIn("age", body["users"][0])
 
 
 if __name__ == "__main__":

--- a/src/oneid/oneid-lambda-client-registration/src/main/java/it/pagopa/oneid/exception/ClientRegistrationServiceException.java
+++ b/src/oneid/oneid-lambda-client-registration/src/main/java/it/pagopa/oneid/exception/ClientRegistrationServiceException.java
@@ -4,7 +4,7 @@ import it.pagopa.oneid.common.model.exception.enums.ErrorCode;
 
 public class ClientRegistrationServiceException extends RuntimeException {
 
-  public ClientRegistrationServiceException() {
-    super(String.valueOf(ErrorCode.CLIENT_UTILS_ERROR));
+  public ClientRegistrationServiceException(ErrorCode errorCode) {
+    super(String.valueOf(errorCode));
   }
 }

--- a/src/oneid/oneid-lambda-client-registration/src/main/java/it/pagopa/oneid/model/dto/ClientRegistrationDTO.java
+++ b/src/oneid/oneid-lambda-client-registration/src/main/java/it/pagopa/oneid/model/dto/ClientRegistrationDTO.java
@@ -79,6 +79,12 @@ public class ClientRegistrationDTO {
   @JsonProperty("pairwise")
   private Boolean pairwise;
 
+  @JsonProperty("minAge")
+  private Integer minAge;
+
+  @JsonProperty("maxAge")
+  private Integer maxAge;
+
   public ClientRegistrationDTO(ClientRegistrationDTO clientRegistrationDTO) {
     this.redirectUris = clientRegistrationDTO.redirectUris;
     this.clientName = clientRegistrationDTO.clientName;
@@ -94,5 +100,7 @@ public class ClientRegistrationDTO {
     this.spidMinors = clientRegistrationDTO.spidMinors;
     this.spidProfessionals = clientRegistrationDTO.spidProfessionals;
     this.pairwise = clientRegistrationDTO.pairwise;
+    this.minAge = clientRegistrationDTO.minAge;
+    this.maxAge = clientRegistrationDTO.maxAge;
   }
 }

--- a/src/oneid/oneid-lambda-client-registration/src/main/java/it/pagopa/oneid/service/ClientRegistrationServiceImpl.java
+++ b/src/oneid/oneid-lambda-client-registration/src/main/java/it/pagopa/oneid/service/ClientRegistrationServiceImpl.java
@@ -15,6 +15,7 @@ import it.pagopa.oneid.common.model.dto.PDVValidateApiKeyDTO;
 import it.pagopa.oneid.common.model.dto.PDVValidationResponseDTO;
 import it.pagopa.oneid.common.model.exception.ClientNotFoundException;
 import it.pagopa.oneid.common.model.exception.ExistingUserIdException;
+import it.pagopa.oneid.common.model.exception.enums.ErrorCode;
 import it.pagopa.oneid.common.utils.HASHUtils;
 import it.pagopa.oneid.common.utils.SSMConnectorUtilsImpl;
 import it.pagopa.oneid.common.utils.logging.CustomLogging;
@@ -64,12 +65,13 @@ public class ClientRegistrationServiceImpl implements ClientRegistrationService 
       @Nullable String planName) {
 
     // validate client name
-    if (!(clientRegistrationDTO.getClientName()!=null && ValidationUtils.isSafeTitle(clientRegistrationDTO.getClientName()))) {
+    if (!(clientRegistrationDTO.getClientName() != null && ValidationUtils.isSafeTitle(
+        clientRegistrationDTO.getClientName()))) {
       throw new InvalidParameterException("Invalid Client name");
     }
 
     // Validate redirectUris
-    if (clientRegistrationDTO.getRedirectUris()!=null) {
+    if (clientRegistrationDTO.getRedirectUris() != null) {
       if (clientRegistrationDTO.getRedirectUris().isEmpty()) {
         throw new InvalidUriException(ClientRegistrationErrorCode.EMPTY_URI);
       }
@@ -133,7 +135,8 @@ public class ClientRegistrationServiceImpl implements ClientRegistrationService 
     Boolean pairWise = clientRegistrationDTO.getPairwise();
     if (Boolean.TRUE.equals(pairWise)) {
       if (isBlank(pdvApiKey) ^ isBlank(planName)) {
-        throw new InvalidPDVPlanException("Both PDV api key and plan name must be provided together");
+        throw new InvalidPDVPlanException(
+            "Both PDV api key and plan name must be provided together");
       }
       if (!isBlank(pdvApiKey) && !isBlank(planName)) {
 
@@ -145,7 +148,7 @@ public class ClientRegistrationServiceImpl implements ClientRegistrationService 
         try {
           PDVValidationResponseDTO res = validatePDVApiKey(req);
 
-          if (res==null || !res.isValid()) {
+          if (res == null || !res.isValid()) {
             throw new InvalidPDVPlanException("PDV validation failed for api key and plan");
           }
 
@@ -203,7 +206,8 @@ public class ClientRegistrationServiceImpl implements ClientRegistrationService 
     // 8. Overwrite clientRegistrationRequestDTO.defaultAcrValues with only its first value
     clientRegistrationDTO.setDefaultAcrValues(Set.of(
         clientRegistrationDTO.getDefaultAcrValues().stream().findFirst()
-            .orElseThrow(ClientRegistrationServiceException::new)));
+            .orElseThrow(
+                () -> new ClientRegistrationServiceException(ErrorCode.CLIENT_UTILS_ERROR))));
 
     // 9. create and return ClientRegistrationResponseDTO
     return ClientRegistrationResponseDTO.builder()
@@ -217,14 +221,14 @@ public class ClientRegistrationServiceImpl implements ClientRegistrationService 
         .samlRequestedAttributes(clientRegistrationDTO.getSamlRequestedAttributes())
         .a11yUri(clientRegistrationDTO.getA11yUri())
         .localizedContentMap(clientRegistrationDTO.getLocalizedContentMap())
-        .backButtonEnabled(clientRegistrationDTO.getBackButtonEnabled()!=null
-            ? clientRegistrationDTO.getBackButtonEnabled():false)
-        .spidMinors(clientRegistrationDTO.getSpidMinors()!=null
-            ? clientRegistrationDTO.getSpidMinors():false)
-        .spidProfessionals(clientRegistrationDTO.getSpidProfessionals()!=null
-            ? clientRegistrationDTO.getSpidProfessionals():false)
-        .pairwise(clientRegistrationDTO.getPairwise()!=null
-            ? clientRegistrationDTO.getPairwise():false)
+        .backButtonEnabled(clientRegistrationDTO.getBackButtonEnabled() != null
+            ? clientRegistrationDTO.getBackButtonEnabled() : false)
+        .spidMinors(clientRegistrationDTO.getSpidMinors() != null
+            ? clientRegistrationDTO.getSpidMinors() : false)
+        .spidProfessionals(clientRegistrationDTO.getSpidProfessionals() != null
+            ? clientRegistrationDTO.getSpidProfessionals() : false)
+        .pairwise(clientRegistrationDTO.getPairwise() != null
+            ? clientRegistrationDTO.getPairwise() : false)
         .clientId(client.getClientId())
         .clientSecret(HASHUtils.b64encoder.encodeToString(clientSecretSalt.secret))
         .clientIdIssuedAt(client.getClientIdIssuedAt())
@@ -256,9 +260,9 @@ public class ClientRegistrationServiceImpl implements ClientRegistrationService 
 
   @Override
   public void updateClientExtended(ClientRegistrationDTO clientRegistrationDTO,
-                                   ClientExtended clientExtended,
-                                   @Nullable String pdvApiKey,
-                                   @Nullable String planName) {
+      ClientExtended clientExtended,
+      @Nullable String pdvApiKey,
+      @Nullable String planName) {
     Client updatedClient = ClientUtils.convertClientRegistrationDTOToClient(clientRegistrationDTO,
         clientExtended.getUserId());
 
@@ -289,7 +293,7 @@ public class ClientRegistrationServiceImpl implements ClientRegistrationService 
 
   private PDVException createPDVException(WebApplicationException e) {
     Response response = e.getResponse();
-    if (response==null) {
+    if (response == null) {
       return new PDVException("PDV response not ok: ", null, Optional.empty(), e);
     }
     Integer status = response.getStatus();

--- a/src/oneid/oneid-lambda-client-registration/src/main/java/it/pagopa/oneid/service/utils/ClientUtils.java
+++ b/src/oneid/oneid-lambda-client-registration/src/main/java/it/pagopa/oneid/service/utils/ClientUtils.java
@@ -47,8 +47,7 @@ public class ClientUtils {
         throw new ClientRegistrationServiceException(ErrorCode.CLIENT_SPID_MINORS_ERROR);
       }
       minAge = clientRegistrationDTO.getMinAge();
-      maxAge = clientRegistrationDTO.getMaxAge() != null
-          ? clientRegistrationDTO.getMaxAge() : 99;
+      maxAge = clientRegistrationDTO.getMaxAge();
     }
 
     //clientID, attributeIndex and clientIdIssuedAt are set outside this method

--- a/src/oneid/oneid-lambda-client-registration/src/main/java/it/pagopa/oneid/service/utils/ClientUtils.java
+++ b/src/oneid/oneid-lambda-client-registration/src/main/java/it/pagopa/oneid/service/utils/ClientUtils.java
@@ -5,6 +5,7 @@ import com.nimbusds.jwt.SignedJWT;
 import io.quarkus.logging.Log;
 import it.pagopa.oneid.common.model.Client;
 import it.pagopa.oneid.common.model.enums.AuthLevel;
+import it.pagopa.oneid.common.model.exception.enums.ErrorCode;
 import it.pagopa.oneid.common.utils.logging.CustomLogging;
 import it.pagopa.oneid.exception.ClientRegistrationServiceException;
 import it.pagopa.oneid.exception.InvalidBearerTokenException;
@@ -36,6 +37,20 @@ public class ClientUtils {
 
     Set<String> callbackUris = clientRegistrationDTO.getRedirectUris();
 
+    boolean spidMinors = clientRegistrationDTO.getSpidMinors() != null
+        && clientRegistrationDTO.getSpidMinors();
+
+    Integer minAge = null;
+    Integer maxAge = null;
+    if (spidMinors) {
+      if (clientRegistrationDTO.getMinAge() == null) {
+        throw new ClientRegistrationServiceException(ErrorCode.CLIENT_SPID_MINORS_ERROR);
+      }
+      minAge = clientRegistrationDTO.getMinAge();
+      maxAge = clientRegistrationDTO.getMaxAge() != null
+          ? clientRegistrationDTO.getMaxAge() : 99;
+    }
+
     //clientID, attributeIndex and clientIdIssuedAt are set outside this method
     return Client.builder()
         .userId(userId)
@@ -44,7 +59,7 @@ public class ClientUtils {
         .requestedParameters(requestedParameters)
         .authLevel(AuthLevel.authLevelFromValue(
             clientRegistrationDTO.getDefaultAcrValues().stream().findFirst()
-                .orElseThrow(ClientRegistrationServiceException::new)))
+                .orElseThrow(() -> new ClientRegistrationServiceException(ErrorCode.CLIENT_UTILS_ERROR))))
         .acsIndex(ACS_INDEX_DEFAULT_VALUE)
         .isActive(true)
         .logoUri(clientRegistrationDTO.getLogoUri())
@@ -54,14 +69,15 @@ public class ClientUtils {
         .localizedContentMap(clientRegistrationDTO.getLocalizedContentMap())
         .backButtonEnabled(clientRegistrationDTO.getBackButtonEnabled() != null
             ? clientRegistrationDTO.getBackButtonEnabled() : false)
-        .spidMinors(clientRegistrationDTO.getSpidMinors() != null
-            ? clientRegistrationDTO.getSpidMinors() : false)
+        .spidMinors(spidMinors)
         .spidProfessionals(clientRegistrationDTO.getSpidProfessionals() != null
             ? clientRegistrationDTO.getSpidProfessionals() : false)
         .pairwise(clientRegistrationDTO.getPairwise() != null
             ? clientRegistrationDTO.getPairwise() : false)
         .requiredSameIdp(clientRegistrationDTO.getRequiredSameIdp() != null
             ? clientRegistrationDTO.getRequiredSameIdp() : false)
+        .minAge(minAge)
+        .maxAge(maxAge)
         .build();
   }
 
@@ -82,6 +98,8 @@ public class ClientUtils {
         .a11yUri(client.getA11yUri())
         .backButtonEnabled(client.isBackButtonEnabled())
         .localizedContentMap(client.getLocalizedContentMap())
+        .minAge(client.getMinAge())
+        .maxAge(client.getMaxAge())
         .build();
 
   }

--- a/src/oneid/oneid-lambda-client-registration/src/test/java/it/pagopa/oneid/service/ClientRegistrationServiceImplTest.java
+++ b/src/oneid/oneid-lambda-client-registration/src/test/java/it/pagopa/oneid/service/ClientRegistrationServiceImplTest.java
@@ -717,6 +717,7 @@ class ClientRegistrationServiceImplTest {
         .localizedContentMap(new HashMap<>())
         .spidMinors(true)
         .spidProfessionals(true)
+        .minAge(14)
         .pairwise(false)
         .build();
 
@@ -804,6 +805,7 @@ class ClientRegistrationServiceImplTest {
         .spidMinors(true)
         .spidProfessionals(true)
         .pairwise(true)
+        .minAge(14)
         .build();
 
     when(ssmConnectorUtilsImplMock.upsertSecureStringIfPresentOnlyIfChanged(Mockito.anyString(),
@@ -861,6 +863,7 @@ class ClientRegistrationServiceImplTest {
         .localizedContentMap(new HashMap<>())
         .spidMinors(true)
         .spidProfessionals(false)
+        .minAge(14)
         //.pairwise() default false
         //.requiredSameIdp() default false
         .build();

--- a/src/oneid/oneid-lambda-client-registration/src/test/java/it/pagopa/oneid/service/ClientRegistrationServiceImplTest.java
+++ b/src/oneid/oneid-lambda-client-registration/src/test/java/it/pagopa/oneid/service/ClientRegistrationServiceImplTest.java
@@ -401,6 +401,71 @@ class ClientRegistrationServiceImplTest {
   }
 
   @Test
+  void saveClient_withSpidMinorsNoMaxAge_ok() {
+
+    ClientRegistrationDTO clientRegistrationDTO = ClientRegistrationDTO.builder()
+        .redirectUris(Set.of("https://test.com"))
+        .clientName("test")
+        .logoUri("https://test.com")
+        .policyUri("https://test.com")
+        .tosUri("https://test.com")
+        .defaultAcrValues(Set.of("test"))
+        .samlRequestedAttributes(Set.of("name"))
+        .a11yUri("https://test.com")
+        .backButtonEnabled(false)
+        .localizedContentMap(new HashMap<>())
+        .spidMinors(true)
+        .spidProfessionals(false)
+        .pairwise(false)
+        .minAge(14)
+        .build();
+
+    when(clientConnectorImpl.findAll()).thenReturn(Optional.of(new ArrayList<>()));
+
+    assertDoesNotThrow(() -> clientRegistrationServiceImpl.saveClient(
+        clientRegistrationDTO, "userId", null, null));
+
+    verify(clientConnectorImpl).saveClientIfNotExists(Mockito.argThat(saved ->
+        saved.isSpidMinors()
+            && saved.getMinAge() == 14
+            && saved.getMaxAge() == null
+    ));
+  }
+
+  @Test
+  void saveClient_withSpidMinorsAndMaxAge_ok() {
+
+    ClientRegistrationDTO clientRegistrationDTO = ClientRegistrationDTO.builder()
+        .redirectUris(Set.of("https://test.com"))
+        .clientName("test")
+        .logoUri("https://test.com")
+        .policyUri("https://test.com")
+        .tosUri("https://test.com")
+        .defaultAcrValues(Set.of("test"))
+        .samlRequestedAttributes(Set.of("name"))
+        .a11yUri("https://test.com")
+        .backButtonEnabled(false)
+        .localizedContentMap(new HashMap<>())
+        .spidMinors(true)
+        .spidProfessionals(false)
+        .pairwise(false)
+        .minAge(14)
+        .maxAge(18)
+        .build();
+
+    when(clientConnectorImpl.findAll()).thenReturn(Optional.of(new ArrayList<>()));
+
+    assertDoesNotThrow(() -> clientRegistrationServiceImpl.saveClient(
+        clientRegistrationDTO, "userId", null, null));
+
+    verify(clientConnectorImpl).saveClientIfNotExists(Mockito.argThat(saved ->
+        saved.isSpidMinors()
+            && saved.getMinAge() == 14
+            && saved.getMaxAge() == 18
+    ));
+  }
+
+  @Test
   void saveClient_WithPairWiseEnabled_ok() {
 
     ClientRegistrationDTO clientRegistrationDTO = ClientRegistrationDTO.builder()
@@ -749,6 +814,8 @@ class ClientRegistrationServiceImplTest {
             && updated.isSpidMinors()
             && updated.isSpidProfessionals()
             && !updated.isPairwise()
+            && updated.getMinAge() == 14
+            && updated.getMaxAge() == null // maxAge not specified
             && updated.getSecret().equals(secret) // unchanged
             && updated.getSalt().equals(salt) // unchanged
     ));
@@ -837,6 +904,8 @@ class ClientRegistrationServiceImplTest {
             && updated.isSpidMinors()
             && updated.isSpidProfessionals()
             && updated.isPairwise()
+            && updated.getMinAge() == 14
+            && updated.getMaxAge() == null // maxAge not specified
             && updated.getSecret().equals(secret) // unchanged
             && updated.getSalt().equals(salt) // unchanged
     ));
@@ -905,8 +974,80 @@ class ClientRegistrationServiceImplTest {
             && !updated.isSpidProfessionals()
             && !updated.isRequiredSameIdp() // default false
             && !updated.isPairwise() // default false
+            && updated.getMinAge() == 14
+            && updated.getMaxAge() == null // maxAge not specified
             && updated.getSecret().equals("originalSecret") // unchanged
             && updated.getSalt().equals("originalSalt") // unchanged
+    ));
+  }
+
+  @Test
+  void updateClient_withSpidMinorsAndMaxAge_ok() {
+    // given
+    String clientId = "client-123";
+    String userId = "userIdTest";
+    int attributeIndex = 42;
+    long originalIssuedAt = 987654321L;
+    String secret = "originalSecret";
+    String salt = "originalSalt";
+
+    ClientExtended existingClientExtended = ClientExtended.builder()
+        .secret(secret)
+        .salt(salt)
+        .clientId(clientId)
+        .userId(userId)
+        .friendlyName("Old Name")
+        .callbackURI(Set.of("https://old.com"))
+        .requestedParameters(Set.of("name"))
+        .authLevel(AuthLevel.L2)
+        .acsIndex(0)
+        .attributeIndex(attributeIndex)
+        .isActive(true)
+        .clientIdIssuedAt(originalIssuedAt)
+        .logoUri("oldLogo")
+        .policyUri("oldPolicy")
+        .tosUri("oldTos")
+        .requiredSameIdp(false)
+        .a11yUri("oldA11y")
+        .backButtonEnabled(false)
+        .localizedContentMap(new HashMap<>())
+        .spidMinors(false)
+        .spidProfessionals(false)
+        .pairwise(false)
+        .build();
+    when(clientConnectorImpl.getClientById(clientId))
+        .thenReturn(Optional.of(existingClientExtended));
+
+    ClientRegistrationDTO clientRegistrationDTO = ClientRegistrationDTO.builder()
+        .redirectUris(Set.of("https://test.com"))
+        .clientName("test")
+        .logoUri("newLogo")
+        .policyUri("newPolicy")
+        .tosUri("newTos")
+        .defaultAcrValues(Set.of(AuthLevel.L2.getValue()))
+        .samlRequestedAttributes(Set.of("name"))
+        .a11yUri("newA11y")
+        .backButtonEnabled(true)
+        .localizedContentMap(new HashMap<>())
+        .spidMinors(true)
+        .spidProfessionals(false)
+        .minAge(14)
+        .maxAge(18)
+        .pairwise(false)
+        .build();
+
+    when(ssmConnectorUtilsImplMock.deleteParameter(Mockito.anyString())).thenReturn(true);
+
+    // when
+    assertDoesNotThrow(() -> clientRegistrationServiceImpl.updateClientExtended(
+        clientRegistrationDTO, existingClientExtended, null, null));
+
+    // then
+    verify(clientConnectorImpl).updateClientExtended(Mockito.argThat(updated ->
+        updated.getClientId().equals(clientId)
+            && updated.isSpidMinors()
+            && updated.getMinAge() == 14
+            && updated.getMaxAge() == 18
     ));
   }
 

--- a/src/oneid/pom.xml
+++ b/src/oneid/pom.xml
@@ -289,6 +289,13 @@
             </modules>
         </profile>
         <profile>
+            <id>oneid-ecs-internal-idp-aggregate</id>
+            <modules>
+                <module>oneid-common</module>
+                <module>oneid-ecs-internal-idp</module>
+            </modules>
+        </profile>
+        <profile>
             <id>oneid-all</id>
             <modules>
                 <module>oneid-common</module>


### PR DESCRIPTION
<!-- You can choose the type of PR (Bug Fix, Refactor, Feature etc.) -->

### What type of PR is this?

- [ ] 🔨 Refactor
- [x] ✨ Feature
- [ ] ⛑️ Bug Fix
- [ ] 🚀 Optimization
- [ ] 📄 Documentation Update
- [ ] ⚠️ Breaking change [ℹ️](## 'Fix or feature that would cause existing functionality to not work as expected')

<!-- You can list all changes included in the PR -->

### List of Changes

This PR introduces support for spidMinors flow, enabling age limit configurations (minAge / maxAge) during client authentication and age config during creation of test users for internal IDP.
Changes by module:
- oneid-ecs-core: Inject the AgeLimit extension into the AuthnRequest when the client's spidMinors flag is true. Default maxAge to 99 (no upper limit) if only minAge is provided.
- oneid-ecs-internal-idp: Add validation for the new test user age field. (Backward compatible: the check is bypassed if the user has no age set). Save minAge and maxAge into the IdpSession during the /samlsso call. Verify the user's age falls within the requested range during the /consent redirect.
- oneid-lambda-client-manager: Add an optional age field to test user creation and update payloads.
- oneid-lambda-client-registration: Support minAge and maxAge fields when creating and updating clients.
- oneid-control-panel: Add a spidMinors boolean toggle for clients. Enabling it exposes minAge and maxAge (nullable) inputs. Add an age attribute input field for test users.

<!-- You can list all Jira task/bug included in the PR -->

### Related Task

- OI-609

<!-- Add a changeset to include this PR in the release notes -->

### Does this PR need a Changeset?

A changeset is a description of changes that should be included in the changelog and release notes. 
If your PR includes significant changes that must be versioned, run `yarn changeset` from the root of the repo and select `oneidentity` plus any other affected package in order to create a changeset.

- [x] 🦋 I have added a changeset by running `yarn changeset`
- [ ] ❌ This PR doesn't require a changeset (e.g., documentation, config changes)

<!-- You can specify how you tested the tasks in the pr -->

### How Has This Been Tested?

- Local tests

<!-- You can add screenshots if necessary -->

### Screenshots (if appropriate)
